### PR TITLE
Prepare package/module for publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 * Easy to use input for searching for places
 * Place suggestions displayed in realtime
 * Google Material Design styling provided by next version of Material-UI (v1)
+* Safe to render on the server (SSR)
 * Thoroughly tested
 
 # Installation

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "author": "Chris Austin <caustin.adwan@gmail.com>",
   "license": "MIT",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "yarn test:mocha && yarn test:eslint",
     "test:mocha": "mocha --require babel-register --require ignore-styles --require test/setup-dom.js test/test.jsx",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:eslint": "eslint --max-warnings 0 --cache --ext .js,.jsx src test demo",
     "demo": "webpack-dev-server --config demo/webpack.config.js --content-base dist --hot",
     "build": "webpack",
-    "prepublish": "webpack"
+    "prepublish": "yarn test && rm -rf dist/ && webpack"
   },
   "dependencies": {
     "autosuggest-highlight": "^3.1.0",

--- a/src/MUIPlacesAutocomplete.jsx
+++ b/src/MUIPlacesAutocomplete.jsx
@@ -127,7 +127,11 @@ export class MUIPlacesAutocomplete extends React.Component {
     this.onChange = this.onChange.bind(this)
   }
 
-  componentWillMount() {
+  componentDidMount() {
+    // After the component is mounted it is safe to create a new instance of the autocomplete
+    // service client. That's because at this point the Google Maps JavaScript API has been loaded.
+    // Also if we do it before the component is mounted (i.e. in 'componentWillMount()') we won't be
+    // safe to render on the server (SSR) as the 'window' object isn't available.
     this.autocompleteService = new window.google.maps.places.AutocompleteService()
   }
 


### PR DESCRIPTION
While going through the documentation on publishing (`npm help publish` & `npm help npm-developers`) I found some issues with our package/module that needed to be resolved. Namely we ensured that the entry point to our package/module pointed to the code we transpiled before be published (i.e. `yarn prepublish`) as well as ensure that our component could be rendered on the server (SSR).