### PR TITLE
Package the `dist` folder (add `.npmignore`)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+node_modules/
+!dist/
+demo/lib
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-places-autocomplete",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Material-UI React component that provides suggestions/autocompletes places using the Google Places API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When reading the `npm-developers` documentation I either
misunderstood/misread/was being an idiot and failed to properly test my
packaging. I believe that I did a test install of the package by
installing from the directory instead of the packaged project (i.e.
.npm/.tgz) itself. As a result I incorrectly assumed that packaging
worked as expected.

When I tried to include the package in another project it was unable to
find the entry point to the package/module as the `dist` folder didn't
get packaged. This was a result of the `.gitignore` file being used as
the `.npmignore` file where the `.gitignore` file ignores the `dist`
folder.

I fixed this problem by including a `.npmignore` file which doesn't
ignore the `dist` folder. I've confirmed it works also by doing a test
install from the packaged .npm/.tgz.

Version bump: 1.0.0 -> 1.0.1
	new file:   .npmignore
	modified:   package.json