### PR TITLE
Upgrade MUI from 1.0.0-beta.17 -> 1.0.0-beta.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-places-autocomplete",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Material-UI React component that provides suggestions/autocompletes places using the Google Places API",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "autosuggest-highlight": "^3.1.0",
-    "material-ui": "1.0.0-beta.17",
+    "material-ui": "1.0.0-beta.21",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-autosuggest": "^9.3.2",

--- a/test/test.jsx.snap
+++ b/test/test.jsx.snap
@@ -182,19 +182,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                     className={undefined}
                     classes={
                       Object {
-                        ".MuiInput-error-8:after": "MuiInput-error-8:after",
-                        ".MuiInput-inkbar-7.MuiInput-focused-12:after": "MuiInput-inkbar-7.MuiInput-focused-12:after",
-                        ".MuiInput-inkbar-7:after": "MuiInput-inkbar-7:after",
-                        ".MuiInput-input-9:-ms-input-placeholder": "MuiInput-input-9:-ms-input-placeholder",
-                        ".MuiInput-input-9::-moz-placeholder": "MuiInput-input-9::-moz-placeholder",
-                        ".MuiInput-input-9::-ms-input-placeholder": "MuiInput-input-9::-ms-input-placeholder",
-                        ".MuiInput-input-9::-webkit-input-placeholder": "MuiInput-input-9::-webkit-input-placeholder",
-                        ".MuiInput-input-9::-webkit-search-decoration": "MuiInput-input-9::-webkit-search-decoration",
-                        ".MuiInput-input-9:focus": "MuiInput-input-9:focus",
-                        ".MuiInput-input-9:invalid": "MuiInput-input-9:invalid",
-                        ".MuiInput-underline-13.MuiInput-disabled-11:before": "MuiInput-underline-13.MuiInput-disabled-11:before",
-                        ".MuiInput-underline-13:before": "MuiInput-underline-13:before",
-                        ".MuiInput-underline-13:hover:not(.MuiInput-disabled-11):before": "MuiInput-underline-13:hover:not(.MuiInput-disabled-11):before",
                         "disabled": "MuiInput-disabled-11",
                         "error": "MuiInput-error-8",
                         "focused": "MuiInput-focused-12",
@@ -207,16 +194,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                         "inputMultiline": "MuiInput-inputMultiline-18",
                         "inputSearch": "MuiInput-inputSearch-17",
                         "inputSingleline": "MuiInput-inputSingleline-16",
-                        "label + .MuiInput-formControl-6": "abel + .MuiInput-formControl-6",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-moz-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-webkit-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus:-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-moz-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-webkit-input-placeholder",
                         "multiline": "MuiInput-multiline-14",
                         "root": "MuiInput-root-5",
                         "underline": "MuiInput-underline-13",
@@ -485,19 +462,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                     className={undefined}
                     classes={
                       Object {
-                        ".MuiInput-error-8:after": "MuiInput-error-8:after",
-                        ".MuiInput-inkbar-7.MuiInput-focused-12:after": "MuiInput-inkbar-7.MuiInput-focused-12:after",
-                        ".MuiInput-inkbar-7:after": "MuiInput-inkbar-7:after",
-                        ".MuiInput-input-9:-ms-input-placeholder": "MuiInput-input-9:-ms-input-placeholder",
-                        ".MuiInput-input-9::-moz-placeholder": "MuiInput-input-9::-moz-placeholder",
-                        ".MuiInput-input-9::-ms-input-placeholder": "MuiInput-input-9::-ms-input-placeholder",
-                        ".MuiInput-input-9::-webkit-input-placeholder": "MuiInput-input-9::-webkit-input-placeholder",
-                        ".MuiInput-input-9::-webkit-search-decoration": "MuiInput-input-9::-webkit-search-decoration",
-                        ".MuiInput-input-9:focus": "MuiInput-input-9:focus",
-                        ".MuiInput-input-9:invalid": "MuiInput-input-9:invalid",
-                        ".MuiInput-underline-13.MuiInput-disabled-11:before": "MuiInput-underline-13.MuiInput-disabled-11:before",
-                        ".MuiInput-underline-13:before": "MuiInput-underline-13:before",
-                        ".MuiInput-underline-13:hover:not(.MuiInput-disabled-11):before": "MuiInput-underline-13:hover:not(.MuiInput-disabled-11):before",
                         "disabled": "MuiInput-disabled-11",
                         "error": "MuiInput-error-8",
                         "focused": "MuiInput-focused-12",
@@ -510,16 +474,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                         "inputMultiline": "MuiInput-inputMultiline-18",
                         "inputSearch": "MuiInput-inputSearch-17",
                         "inputSingleline": "MuiInput-inputSingleline-16",
-                        "label + .MuiInput-formControl-6": "abel + .MuiInput-formControl-6",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-moz-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-webkit-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus:-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-moz-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-webkit-input-placeholder",
                         "multiline": "MuiInput-multiline-14",
                         "root": "MuiInput-root-5",
                         "underline": "MuiInput-underline-13",
@@ -660,8 +614,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                     <MenuItem
                       classes={
                         Object {
-                          ".MuiMenuItem-root-20:focus": "MuiMenuItem-root-20:focus",
-                          ".MuiMenuItem-root-20:hover": "MuiMenuItem-root-20:hover",
                           "root": "MuiMenuItem-root-20",
                           "selected": "MuiMenuItem-selected-21",
                         }
@@ -682,8 +634,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                           className="MuiMenuItem-root-20"
                           classes={
                             Object {
-                              ".MuiListItem-button-30:hover": "MuiListItem-button-30:hover",
-                              ".MuiListItem-button-30:hover.MuiListItem-disabled-27": "MuiListItem-button-30:hover.MuiListItem-disabled-27",
                               "button": "MuiListItem-button-30",
                               "container": "MuiListItem-container-23",
                               "default": "MuiListItem-default-25",
@@ -778,9 +728,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                                     center={false}
                                     classes={
                                       Object {
-                                        "0%": "%",
-                                        "100%": "00%",
-                                        "50%": "0%",
                                         "ripple": "MuiTouchRipple-ripple-38",
                                         "rippleFast": "MuiTouchRipple-rippleFast-40",
                                         "rippleVisible": "MuiTouchRipple-rippleVisible-39",
@@ -1023,19 +970,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                     className={undefined}
                     classes={
                       Object {
-                        ".MuiInput-error-8:after": "MuiInput-error-8:after",
-                        ".MuiInput-inkbar-7.MuiInput-focused-12:after": "MuiInput-inkbar-7.MuiInput-focused-12:after",
-                        ".MuiInput-inkbar-7:after": "MuiInput-inkbar-7:after",
-                        ".MuiInput-input-9:-ms-input-placeholder": "MuiInput-input-9:-ms-input-placeholder",
-                        ".MuiInput-input-9::-moz-placeholder": "MuiInput-input-9::-moz-placeholder",
-                        ".MuiInput-input-9::-ms-input-placeholder": "MuiInput-input-9::-ms-input-placeholder",
-                        ".MuiInput-input-9::-webkit-input-placeholder": "MuiInput-input-9::-webkit-input-placeholder",
-                        ".MuiInput-input-9::-webkit-search-decoration": "MuiInput-input-9::-webkit-search-decoration",
-                        ".MuiInput-input-9:focus": "MuiInput-input-9:focus",
-                        ".MuiInput-input-9:invalid": "MuiInput-input-9:invalid",
-                        ".MuiInput-underline-13.MuiInput-disabled-11:before": "MuiInput-underline-13.MuiInput-disabled-11:before",
-                        ".MuiInput-underline-13:before": "MuiInput-underline-13:before",
-                        ".MuiInput-underline-13:hover:not(.MuiInput-disabled-11):before": "MuiInput-underline-13:hover:not(.MuiInput-disabled-11):before",
                         "disabled": "MuiInput-disabled-11",
                         "error": "MuiInput-error-8",
                         "focused": "MuiInput-focused-12",
@@ -1048,16 +982,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                         "inputMultiline": "MuiInput-inputMultiline-18",
                         "inputSearch": "MuiInput-inputSearch-17",
                         "inputSingleline": "MuiInput-inputSingleline-16",
-                        "label + .MuiInput-formControl-6": "abel + .MuiInput-formControl-6",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-moz-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-webkit-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus:-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-moz-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-webkit-input-placeholder",
                         "multiline": "MuiInput-multiline-14",
                         "root": "MuiInput-root-5",
                         "underline": "MuiInput-underline-13",
@@ -1326,19 +1250,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                     className={undefined}
                     classes={
                       Object {
-                        ".MuiInput-error-8:after": "MuiInput-error-8:after",
-                        ".MuiInput-inkbar-7.MuiInput-focused-12:after": "MuiInput-inkbar-7.MuiInput-focused-12:after",
-                        ".MuiInput-inkbar-7:after": "MuiInput-inkbar-7:after",
-                        ".MuiInput-input-9:-ms-input-placeholder": "MuiInput-input-9:-ms-input-placeholder",
-                        ".MuiInput-input-9::-moz-placeholder": "MuiInput-input-9::-moz-placeholder",
-                        ".MuiInput-input-9::-ms-input-placeholder": "MuiInput-input-9::-ms-input-placeholder",
-                        ".MuiInput-input-9::-webkit-input-placeholder": "MuiInput-input-9::-webkit-input-placeholder",
-                        ".MuiInput-input-9::-webkit-search-decoration": "MuiInput-input-9::-webkit-search-decoration",
-                        ".MuiInput-input-9:focus": "MuiInput-input-9:focus",
-                        ".MuiInput-input-9:invalid": "MuiInput-input-9:invalid",
-                        ".MuiInput-underline-13.MuiInput-disabled-11:before": "MuiInput-underline-13.MuiInput-disabled-11:before",
-                        ".MuiInput-underline-13:before": "MuiInput-underline-13:before",
-                        ".MuiInput-underline-13:hover:not(.MuiInput-disabled-11):before": "MuiInput-underline-13:hover:not(.MuiInput-disabled-11):before",
                         "disabled": "MuiInput-disabled-11",
                         "error": "MuiInput-error-8",
                         "focused": "MuiInput-focused-12",
@@ -1351,16 +1262,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                         "inputMultiline": "MuiInput-inputMultiline-18",
                         "inputSearch": "MuiInput-inputSearch-17",
                         "inputSingleline": "MuiInput-inputSingleline-16",
-                        "label + .MuiInput-formControl-6": "abel + .MuiInput-formControl-6",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-moz-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9::-webkit-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus:-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus:-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-moz-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-moz-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-ms-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-ms-input-placeholder",
-                        "label[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-webkit-input-placeholder": "abel[data-shrink=false] + .MuiInput-formControl-6 .MuiInput-input-9:focus::-webkit-input-placeholder",
                         "multiline": "MuiInput-multiline-14",
                         "root": "MuiInput-root-5",
                         "underline": "MuiInput-underline-13",
@@ -1501,8 +1402,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                     <MenuItem
                       classes={
                         Object {
-                          ".MuiMenuItem-root-20:focus": "MuiMenuItem-root-20:focus",
-                          ".MuiMenuItem-root-20:hover": "MuiMenuItem-root-20:hover",
                           "root": "MuiMenuItem-root-20",
                           "selected": "MuiMenuItem-selected-21",
                         }
@@ -1523,8 +1422,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                           className="MuiMenuItem-root-20"
                           classes={
                             Object {
-                              ".MuiListItem-button-30:hover": "MuiListItem-button-30:hover",
-                              ".MuiListItem-button-30:hover.MuiListItem-disabled-27": "MuiListItem-button-30:hover.MuiListItem-disabled-27",
                               "button": "MuiListItem-button-30",
                               "container": "MuiListItem-container-23",
                               "default": "MuiListItem-default-25",
@@ -1619,9 +1516,6 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                                     center={false}
                                     classes={
                                       Object {
-                                        "0%": "%",
-                                        "100%": "00%",
-                                        "50%": "0%",
                                         "ripple": "MuiTouchRipple-ripple-38",
                                         "rippleFast": "MuiTouchRipple-rippleFast-40",
                                         "rippleVisible": "MuiTouchRipple-rippleVisible-39",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1018,10 +1018,6 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-brcast@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brcast/-/brcast-2.0.2.tgz#2db16de44140e418dc37fab10beec0369e78dcef"
-
 brcast@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/brcast/-/brcast-3.0.1.tgz#6256a8349b20de9eed44257a9b24d71493cd48dd"
@@ -1448,14 +1444,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.6.0:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -1580,9 +1568,9 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.0.tgz#35f7ee08e8bde1173b3a529f732dcda67ce82e29"
+deepmerge@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
 
 define-properties@^1.1.2:
   version "1.1.2"
@@ -2262,7 +2250,7 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.1, fbjs@^0.8.16:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -2647,10 +2635,6 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
-hoist-non-react-statics@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
-
 hoist-non-react-statics@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
@@ -2960,7 +2944,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-in-browser@^1.0.2:
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
@@ -2975,6 +2959,12 @@ is-number@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
+
+is-observable@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-0.2.0.tgz#b361311d83c6e5d726cabf5e250b0237106f5ae2"
+  dependencies:
+    symbol-observable "^0.2.2"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -3236,75 +3226,82 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jss-camel-case@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-5.0.0.tgz#886c1fe56a8a11577454d6a8b4133caa6c1f53a0"
-
-jss-compose@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jss-compose/-/jss-compose-4.0.0.tgz#f0109e8e8301a2678279301c24523dbc76115b9b"
-  dependencies:
-    warning "^3.0.0"
-
-jss-default-unit@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-7.0.0.tgz#176c1db91da870e3ad16301f6f4b4cfc6fe1e90a"
-
-jss-expand@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jss-expand/-/jss-expand-4.0.1.tgz#e8c50e0ac42e7feb6dcaf01212f6607193c1ae80"
-
-jss-extend@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jss-extend/-/jss-extend-5.0.0.tgz#08a1d4015d05dfe011e3a281457d471226865387"
-  dependencies:
-    warning "^3.0.0"
-
-jss-global@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-2.0.0.tgz#a162f822f17e5d760151d908bdb41d7f2824c28f"
-
-jss-nested@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-5.0.0.tgz#c0752f31f2d465110d7de6ac83583dbed669faa0"
-  dependencies:
-    warning "^3.0.0"
-
-jss-preset-default@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/jss-preset-default/-/jss-preset-default-3.0.0.tgz#e43ee1ac526f689baf2bfd28ae95a6fdc3a02663"
-  dependencies:
-    jss-camel-case "^5.0.0"
-    jss-compose "^4.0.0"
-    jss-default-unit "^7.0.0"
-    jss-expand "^4.0.0"
-    jss-extend "^5.0.0"
-    jss-global "^2.0.0"
-    jss-nested "^5.0.0"
-    jss-props-sort "^5.0.0"
-    jss-vendor-prefixer "^6.0.0"
-
-jss-props-sort@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-5.0.0.tgz#8839c88433f64e8c1dab1a7068796f19b84f9195"
-
-jss-rtl@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/jss-rtl/-/jss-rtl-0.2.1.tgz#06fcde4a9369f8c6f660b700f1c68a5d7742eebb"
-  dependencies:
-    rtl-css-js "^1.7.0"
-
-jss-vendor-prefixer@^6.0.0:
+jss-camel-case@^6.0.0:
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/jss-vendor-prefixer/-/jss-vendor-prefixer-6.0.0.tgz#be58124f0cbed76e98cc8eb5219dbb260f057d0b"
+  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-6.0.0.tgz#7cf8453e395c31fed931d11efbc885edcd61132e"
+
+jss-compose@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jss-compose/-/jss-compose-5.0.0.tgz#ce01b2e4521d65c37ea42cf49116e5f7ab596484"
+  dependencies:
+    warning "^3.0.0"
+
+jss-default-unit@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-8.0.0.tgz#a308ead4f587ebe17cc845f9870867400de90910"
+  dependencies:
+    is-observable "^0.2.0"
+
+jss-expand@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jss-expand/-/jss-expand-5.0.0.tgz#8eadb782f29ec5f1d285451dd38052d5ac51644a"
+  dependencies:
+    is-observable "^0.2.0"
+
+jss-extend@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jss-extend/-/jss-extend-6.0.1.tgz#e53430bc92a42e50d036883ccfecfbc4e1199147"
+  dependencies:
+    is-observable "^0.2.0"
+    warning "^3.0.0"
+
+jss-global@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-3.0.0.tgz#e19e5c91ab2b96353c227e30aa2cbd938cdaafa2"
+
+jss-nested@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-6.0.1.tgz#ef992b79d6e8f63d939c4397b9d99b5cbbe824ca"
+  dependencies:
+    warning "^3.0.0"
+
+jss-preset-default@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jss-preset-default/-/jss-preset-default-4.0.1.tgz#822cecb87c27ff91633774422f4c221d61486b65"
+  dependencies:
+    jss-camel-case "^6.0.0"
+    jss-compose "^5.0.0"
+    jss-default-unit "^8.0.0"
+    jss-expand "^5.0.0"
+    jss-extend "^6.0.1"
+    jss-global "^3.0.0"
+    jss-nested "^6.0.1"
+    jss-props-sort "^6.0.0"
+    jss-template "^1.0.0"
+    jss-vendor-prefixer "^7.0.0"
+
+jss-props-sort@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-6.0.0.tgz#9105101a3b5071fab61e2d85ea74cc22e9b16323"
+
+jss-template@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jss-template/-/jss-template-1.0.0.tgz#4b874608706ddceecacdb5567e254aecb6ea69b3"
+  dependencies:
+    warning "^3.0.0"
+
+jss-vendor-prefixer@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz#0166729650015ef19d9f02437c73667231605c71"
   dependencies:
     css-vendor "^0.3.8"
 
-jss@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/jss/-/jss-8.1.0.tgz#b32f15efcce22446dfda4c2be09a04f38431da0a"
+jss@^9.3.1, jss@^9.3.2:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-9.3.3.tgz#d535ad8c64f6df9aeadb0219d5153c47493ff1c0"
   dependencies:
-    is-in-browser "^1.0.2"
+    is-in-browser "^1.1.3"
+    symbol-observable "^1.0.4"
     warning "^3.0.0"
 
 jsx-ast-utils@^1.4.0:
@@ -3463,27 +3460,26 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-material-ui@1.0.0-beta.17:
-  version "1.0.0-beta.17"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.17.tgz#ae09aac7902fdf3b38ec796e03b32461a7ce01fc"
+material-ui@1.0.0-beta.21:
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.21.tgz#3a28fb4dcb27f8d8db19b48c008522389bf39f2d"
   dependencies:
     babel-runtime "^6.26.0"
     brcast "^3.0.1"
     classnames "^2.2.5"
-    deepmerge "^2.0.0"
+    deepmerge "^2.0.1"
     dom-helpers "^3.2.1"
-    hoist-non-react-statics "^1.2.0"
-    jss "^8.1.0"
-    jss-preset-default "^3.0.0"
-    jss-rtl "^0.2.1"
+    hoist-non-react-statics "^2.3.1"
+    jss "^9.3.1"
+    jss-preset-default "^4.0.1"
     keycode "^2.1.9"
     lodash "^4.17.4"
     normalize-scroll-left "^0.1.2"
     prop-types "^15.6.0"
     react-event-listener "^0.5.1"
-    react-flow-types "^0.2.0-beta.2"
-    react-jss "^7.2.0"
-    react-popper "^0.7.3"
+    react-flow-types "0.2.0-beta.3"
+    react-jss "^8.0.0"
+    react-popper "^0.7.4"
     react-scrollbar-size "^2.0.2"
     react-transition-group "^2.2.1"
     recompose "^0.26.0"
@@ -4331,23 +4327,23 @@ react-event-listener@^0.5.0, react-event-listener@^0.5.1:
     prop-types "^15.6.0"
     warning "^3.0.0"
 
-react-flow-types@^0.2.0-beta.2:
-  version "0.2.0-beta.2"
-  resolved "https://registry.yarnpkg.com/react-flow-types/-/react-flow-types-0.2.0-beta.2.tgz#4f9e07fa60230708d067612750f60c7a9ea42d81"
+react-flow-types@0.2.0-beta.3:
+  version "0.2.0-beta.3"
+  resolved "https://registry.yarnpkg.com/react-flow-types/-/react-flow-types-0.2.0-beta.3.tgz#93e7e3c95a75a1a941de05b9d7287e3ca6871046"
 
-react-jss@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-7.2.0.tgz#30a5ed51d8388a33767c6d19790b222c1f33f48f"
+react-jss@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-8.1.0.tgz#7eefe3d121d31d5650118fc4f6b119e388cd43ba"
   dependencies:
-    hoist-non-react-statics "^1.2.0"
-    jss "^8.1.0"
-    jss-preset-default "^3.0.0"
-    prop-types "^15.5.8"
-    theming "^1.1.0"
+    hoist-non-react-statics "^2.3.1"
+    jss "^9.3.2"
+    jss-preset-default "^4.0.1"
+    prop-types "^15.6.0"
+    theming "^1.2.1"
 
-react-popper@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.7.3.tgz#fa2809a80fbe7ec516e9bac01d81bc47a8b5cd3b"
+react-popper@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.7.4.tgz#8649d539837e7c6f47bc9b24c9cf57a404e199a1"
   dependencies:
     popper.js "^1.12.5"
     prop-types "^15.5.10"
@@ -4383,16 +4379,6 @@ react-transition-group@^2.2.1:
     loose-envify "^1.3.1"
     prop-types "^15.5.8"
     warning "^3.0.0"
-
-react@^15.5.4:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
-  dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
 
 react@^16.0.0:
   version "16.0.0"
@@ -4688,10 +4674,6 @@ rst-selector-parser@^2.2.2:
   dependencies:
     lodash.flattendeep "^4.4.0"
     nearley "^2.7.10"
-
-rtl-css-js@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.7.0.tgz#0a9b0a5ddcc7181b0b41977264f39647ba705770"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -5040,6 +5022,10 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+symbol-observable@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
+
 symbol-observable@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
@@ -5088,15 +5074,14 @@ text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
-theming@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/theming/-/theming-1.1.0.tgz#0562760b55a1b919c2d5eeb94130351f8958e13a"
+theming@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/theming/-/theming-1.2.1.tgz#3de0be696339c6c203013a6c68d1c1057973dc44"
   dependencies:
-    brcast "^2.0.0"
+    brcast "^3.0.1"
     is-function "^1.0.1"
     is-plain-object "^2.0.1"
     prop-types "^15.5.8"
-    react "^15.5.4"
 
 through@^2.3.6:
   version "2.3.8"


### PR DESCRIPTION
This commit upgrades the material-ui package/module from version
1.0.0-beta.17 to 1.0.0-beta.21. This upgrade was prompted by the issue
described in #7.

Version bump: 1.0.1 -> 1.0.2
	modified:   package.json
	modified:   test/test.jsx.snap
	modified:   yarn.lock