### PR TITLE
Bug fix: Set 'react' and 'material-ui' as 'peerDependencies'

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,16 +14,17 @@
     "test:mocha": "mocha --require babel-register --require ignore-styles --require test/setup-dom.js test/test.jsx",
     "test:eslint": "eslint --max-warnings 0 --cache --ext .js,.jsx src test demo",
     "demo": "webpack-dev-server --config demo/webpack.config.js --content-base dist --hot",
-    "build": "webpack",
-    "prepublish": "yarn test && rm -rf dist/ && webpack"
+    "build": "rm -rf dist/ && webpack",
+    "prepublish": "yarn test && yarn build"
   },
   "dependencies": {
     "autosuggest-highlight": "^3.1.0",
-    "material-ui": "1.0.0-beta.21",
     "prop-types": "^15.6.0",
-    "react": "^16.0.0",
-    "react-autosuggest": "^9.3.2",
-    "react-dom": "^16.0.0"
+    "react-autosuggest": "^9.3.2"
+  },
+  "peerDependencies": {
+    "material-ui": "^1.0.0-beta.21",
+    "react": "^16.0.0"
   },
   "devDependencies": {
     "@google/maps": "^0.4.5",
@@ -50,9 +51,13 @@
     "html-webpack-plugin": "^2.30.1",
     "ignore-styles": "^5.0.1",
     "jsdom": "^11.3.0",
+    "material-ui": "^1.0.0-beta.21",
     "mocha": "^4.0.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "webpack": "^3.7.1",
-    "webpack-dev-server": "^2.9.1"
+    "webpack-dev-server": "^2.9.1",
+    "webpack-node-externals": "^1.6.0"
   },
   "contributors": [
     "Chris Austin <caustin.adwan@gmail.com>",

--- a/test/test.jsx.snap
+++ b/test/test.jsx.snap
@@ -182,21 +182,21 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                     className={undefined}
                     classes={
                       Object {
-                        "disabled": "MuiInput-disabled-11",
+                        "disabled": "MuiInput-disabled-9",
                         "error": "MuiInput-error-8",
-                        "focused": "MuiInput-focused-12",
+                        "focused": "MuiInput-focused-10",
                         "formControl": "MuiInput-formControl-6",
-                        "fullWidth": "MuiInput-fullWidth-19",
+                        "fullWidth": "MuiInput-fullWidth-13",
                         "inkbar": "MuiInput-inkbar-7",
-                        "input": "MuiInput-input-9",
-                        "inputDense": "MuiInput-inputDense-10",
-                        "inputDisabled": "MuiInput-inputDisabled-15",
+                        "input": "MuiInput-input-14",
+                        "inputDense": "MuiInput-inputDense-15",
+                        "inputDisabled": "MuiInput-inputDisabled-16",
                         "inputMultiline": "MuiInput-inputMultiline-18",
-                        "inputSearch": "MuiInput-inputSearch-17",
-                        "inputSingleline": "MuiInput-inputSingleline-16",
-                        "multiline": "MuiInput-multiline-14",
+                        "inputSearch": "MuiInput-inputSearch-19",
+                        "inputSingleline": "MuiInput-inputSingleline-17",
+                        "multiline": "MuiInput-multiline-12",
                         "root": "MuiInput-root-5",
-                        "underline": "MuiInput-underline-13",
+                        "underline": "MuiInput-underline-11",
                       }
                     }
                     defaultValue={undefined}
@@ -226,7 +226,7 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                       aria-expanded={false}
                       aria-haspopup={false}
                       aria-owns="react-autowhatever-1"
-                      className="MuiInput-root-5 MuiInput-focused-12 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-13"
+                      className="MuiInput-root-5 MuiInput-focused-10 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-11"
                       onBlur={[Function]}
                       onFocus={[Function]}
                       role="combobox"
@@ -235,7 +235,7 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                       <input
                         autoComplete="off"
                         autoFocus={true}
-                        className="MuiInput-input-9 MuiInput-inputSingleline-16"
+                        className="MuiInput-input-14 MuiInput-inputSingleline-17"
                         defaultValue={undefined}
                         disabled={false}
                         id={undefined}
@@ -462,21 +462,21 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                     className={undefined}
                     classes={
                       Object {
-                        "disabled": "MuiInput-disabled-11",
+                        "disabled": "MuiInput-disabled-9",
                         "error": "MuiInput-error-8",
-                        "focused": "MuiInput-focused-12",
+                        "focused": "MuiInput-focused-10",
                         "formControl": "MuiInput-formControl-6",
-                        "fullWidth": "MuiInput-fullWidth-19",
+                        "fullWidth": "MuiInput-fullWidth-13",
                         "inkbar": "MuiInput-inkbar-7",
-                        "input": "MuiInput-input-9",
-                        "inputDense": "MuiInput-inputDense-10",
-                        "inputDisabled": "MuiInput-inputDisabled-15",
+                        "input": "MuiInput-input-14",
+                        "inputDense": "MuiInput-inputDense-15",
+                        "inputDisabled": "MuiInput-inputDisabled-16",
                         "inputMultiline": "MuiInput-inputMultiline-18",
-                        "inputSearch": "MuiInput-inputSearch-17",
-                        "inputSingleline": "MuiInput-inputSingleline-16",
-                        "multiline": "MuiInput-multiline-14",
+                        "inputSearch": "MuiInput-inputSearch-19",
+                        "inputSingleline": "MuiInput-inputSingleline-17",
+                        "multiline": "MuiInput-multiline-12",
                         "root": "MuiInput-root-5",
-                        "underline": "MuiInput-underline-13",
+                        "underline": "MuiInput-underline-11",
                       }
                     }
                     defaultValue={undefined}
@@ -506,7 +506,7 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                       aria-expanded={true}
                       aria-haspopup={true}
                       aria-owns="react-autowhatever-1"
-                      className="MuiInput-root-5 MuiInput-focused-12 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-13"
+                      className="MuiInput-root-5 MuiInput-focused-10 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-11"
                       onBlur={[Function]}
                       onFocus={[Function]}
                       role="combobox"
@@ -515,7 +515,7 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                       <input
                         autoComplete="off"
                         autoFocus={true}
-                        className="MuiInput-input-9 MuiInput-inputSingleline-16"
+                        className="MuiInput-input-14 MuiInput-inputSingleline-17"
                         defaultValue={undefined}
                         disabled={false}
                         id={undefined}
@@ -970,21 +970,21 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                     className={undefined}
                     classes={
                       Object {
-                        "disabled": "MuiInput-disabled-11",
+                        "disabled": "MuiInput-disabled-9",
                         "error": "MuiInput-error-8",
-                        "focused": "MuiInput-focused-12",
+                        "focused": "MuiInput-focused-10",
                         "formControl": "MuiInput-formControl-6",
-                        "fullWidth": "MuiInput-fullWidth-19",
+                        "fullWidth": "MuiInput-fullWidth-13",
                         "inkbar": "MuiInput-inkbar-7",
-                        "input": "MuiInput-input-9",
-                        "inputDense": "MuiInput-inputDense-10",
-                        "inputDisabled": "MuiInput-inputDisabled-15",
+                        "input": "MuiInput-input-14",
+                        "inputDense": "MuiInput-inputDense-15",
+                        "inputDisabled": "MuiInput-inputDisabled-16",
                         "inputMultiline": "MuiInput-inputMultiline-18",
-                        "inputSearch": "MuiInput-inputSearch-17",
-                        "inputSingleline": "MuiInput-inputSingleline-16",
-                        "multiline": "MuiInput-multiline-14",
+                        "inputSearch": "MuiInput-inputSearch-19",
+                        "inputSingleline": "MuiInput-inputSingleline-17",
+                        "multiline": "MuiInput-multiline-12",
                         "root": "MuiInput-root-5",
-                        "underline": "MuiInput-underline-13",
+                        "underline": "MuiInput-underline-11",
                       }
                     }
                     defaultValue={undefined}
@@ -1014,7 +1014,7 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                       aria-expanded={false}
                       aria-haspopup={false}
                       aria-owns="react-autowhatever-1"
-                      className="MuiInput-root-5 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-13"
+                      className="MuiInput-root-5 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-11"
                       onBlur={[Function]}
                       onFocus={[Function]}
                       role="combobox"
@@ -1023,7 +1023,7 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                       <input
                         autoComplete="off"
                         autoFocus={true}
-                        className="MuiInput-input-9 MuiInput-inputSingleline-16"
+                        className="MuiInput-input-14 MuiInput-inputSingleline-17"
                         defaultValue={undefined}
                         disabled={false}
                         id={undefined}
@@ -1250,21 +1250,21 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                     className={undefined}
                     classes={
                       Object {
-                        "disabled": "MuiInput-disabled-11",
+                        "disabled": "MuiInput-disabled-9",
                         "error": "MuiInput-error-8",
-                        "focused": "MuiInput-focused-12",
+                        "focused": "MuiInput-focused-10",
                         "formControl": "MuiInput-formControl-6",
-                        "fullWidth": "MuiInput-fullWidth-19",
+                        "fullWidth": "MuiInput-fullWidth-13",
                         "inkbar": "MuiInput-inkbar-7",
-                        "input": "MuiInput-input-9",
-                        "inputDense": "MuiInput-inputDense-10",
-                        "inputDisabled": "MuiInput-inputDisabled-15",
+                        "input": "MuiInput-input-14",
+                        "inputDense": "MuiInput-inputDense-15",
+                        "inputDisabled": "MuiInput-inputDisabled-16",
                         "inputMultiline": "MuiInput-inputMultiline-18",
-                        "inputSearch": "MuiInput-inputSearch-17",
-                        "inputSingleline": "MuiInput-inputSingleline-16",
-                        "multiline": "MuiInput-multiline-14",
+                        "inputSearch": "MuiInput-inputSearch-19",
+                        "inputSingleline": "MuiInput-inputSingleline-17",
+                        "multiline": "MuiInput-multiline-12",
                         "root": "MuiInput-root-5",
-                        "underline": "MuiInput-underline-13",
+                        "underline": "MuiInput-underline-11",
                       }
                     }
                     defaultValue={undefined}
@@ -1294,7 +1294,7 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                       aria-expanded={true}
                       aria-haspopup={true}
                       aria-owns="react-autowhatever-1"
-                      className="MuiInput-root-5 MuiInput-focused-12 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-13"
+                      className="MuiInput-root-5 MuiInput-focused-10 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-11"
                       onBlur={[Function]}
                       onFocus={[Function]}
                       role="combobox"
@@ -1303,7 +1303,7 @@ exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for giv
                       <input
                         autoComplete="off"
                         autoFocus={true}
-                        className="MuiInput-input-9 MuiInput-inputSingleline-16"
+                        className="MuiInput-input-14 MuiInput-inputSingleline-17"
                         defaultValue={undefined}
                         disabled={false}
                         id={undefined}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const nodeExternals = require('webpack-node-externals')
 
 module.exports = {
   entry: path.join(__dirname, './src/index.js'),
@@ -9,6 +10,15 @@ module.exports = {
     // Definition
     libraryTarget: 'umd',
   },
+  // 'externals' provides us a way of excluding dependencies from the output of the bundle. In this
+  // case we use 'webpack-node-externals' to build/exclude all dependencies as found in
+  // 'node_modules' and then we whitelist our few 'dependencies' found in 'package.json'. This way
+  // we don't bundle up 'material-ui' and 'react' causing module duplication (which causes things
+  // to break) while still allowing our component to be consumed off the shelf by bundling our few
+  // 'dependencies'.
+  externals: [nodeExternals({
+    whitelist: ['autosuggest-highlight', 'prop-types', 'react-autosuggest'],
+  })],
   module: {
     loaders: [
       { test: /\.js$/, loader: 'babel-loader', exclude: [/node_modules/] },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3296,7 +3296,7 @@ jss-vendor-prefixer@^7.0.0:
   dependencies:
     css-vendor "^0.3.8"
 
-jss@^9.3.1, jss@^9.3.2:
+jss@^9.3.2, jss@^9.3.3:
   version "9.3.3"
   resolved "https://registry.yarnpkg.com/jss/-/jss-9.3.3.tgz#d535ad8c64f6df9aeadb0219d5153c47493ff1c0"
   dependencies:
@@ -3460,9 +3460,9 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
-material-ui@1.0.0-beta.21:
-  version "1.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.21.tgz#3a28fb4dcb27f8d8db19b48c008522389bf39f2d"
+material-ui@^1.0.0-beta.21:
+  version "1.0.0-beta.22"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-1.0.0-beta.22.tgz#04e719f33230ec9eab2dd1361b44509f3ec4d98b"
   dependencies:
     babel-runtime "^6.26.0"
     brcast "^3.0.1"
@@ -3470,15 +3470,15 @@ material-ui@1.0.0-beta.21:
     deepmerge "^2.0.1"
     dom-helpers "^3.2.1"
     hoist-non-react-statics "^2.3.1"
-    jss "^9.3.1"
+    jss "^9.3.3"
     jss-preset-default "^4.0.1"
     keycode "^2.1.9"
     lodash "^4.17.4"
     normalize-scroll-left "^0.1.2"
     prop-types "^15.6.0"
     react-event-listener "^0.5.1"
-    react-flow-types "0.2.0-beta.3"
-    react-jss "^8.0.0"
+    react-flow-types "^0.2.0-beta.6"
+    react-jss "^8.1.0"
     react-popper "^0.7.4"
     react-scrollbar-size "^2.0.2"
     react-transition-group "^2.2.1"
@@ -4107,8 +4107,8 @@ pn@^1.0.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.0.0.tgz#1cf5a30b0d806cd18f88fc41a6b5d4ad615b3ba9"
 
 popper.js@^1.12.5:
-  version "1.12.5"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.5.tgz#229e4dea01629e1f1a1e26991ffade5024220fa6"
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.13.0.tgz#e1e7ff65cc43f7cf9cf16f1510a75e81f84f4565"
 
 portfinder@^1.0.9:
   version "1.0.13"
@@ -4310,8 +4310,8 @@ react-autowhatever@^10.1.0:
     section-iterator "^2.0.0"
 
 react-dom@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -4327,11 +4327,11 @@ react-event-listener@^0.5.0, react-event-listener@^0.5.1:
     prop-types "^15.6.0"
     warning "^3.0.0"
 
-react-flow-types@0.2.0-beta.3:
-  version "0.2.0-beta.3"
-  resolved "https://registry.yarnpkg.com/react-flow-types/-/react-flow-types-0.2.0-beta.3.tgz#93e7e3c95a75a1a941de05b9d7287e3ca6871046"
+react-flow-types@^0.2.0-beta.6:
+  version "0.2.0-beta.6"
+  resolved "https://registry.yarnpkg.com/react-flow-types/-/react-flow-types-0.2.0-beta.6.tgz#bf49c8b7864fcd0951b03286c63a80d66ce9fae4"
 
-react-jss@^8.0.0:
+react-jss@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-8.1.0.tgz#7eefe3d121d31d5650118fc4f6b119e388cd43ba"
   dependencies:
@@ -4381,8 +4381,8 @@ react-transition-group@^2.2.1:
     warning "^3.0.0"
 
 react@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.2.0.tgz#a31bd2dab89bff65d42134fa187f24d054c273ba"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -5027,8 +5027,8 @@ symbol-observable@^0.2.2:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
 
 symbol-observable@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.1.0.tgz#5c68fd8d54115d9dfb72a84720549222e8db9b32"
 
 symbol-tree@^3.2.1:
   version "3.2.2"
@@ -5378,6 +5378,10 @@ webpack-dev-server@^2.9.1:
     supports-color "^4.2.1"
     webpack-dev-middleware "^1.11.0"
     yargs "^6.6.0"
+
+webpack-node-externals@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.6.0.tgz#232c62ec6092b100635a3d29d83c1747128df9bd"
 
 webpack-sources@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This commit fixes an issue where we were bundling up 'react' and
'material-ui'. This was bad as since we expect our
component/module/package to be consumed we can be certain that the
consumers already have the 'react' and 'material-ui' modules as
dependencies. As a result duplicate modules were loaded which caused
problems such as MUI components/elements to lose their styling in SSR
use cases.

We fix the issue by setting the 'react' and 'material-ui' modules as
'peerDependencies' to our package. We do add them as 'devDependencies'
so that work can be done on our component directly in this repo/package
folder. To ensure that we don't bundle 'react' and 'material-ui' when we
install them as 'devDependencies' we use 'webpack-node-externals' to
cause webpack to exclude everything in 'node_modules' from being bundled
and then whitelisting our few actual 'dependencies'.

This commit fixes bug: #7
	modified:   package.json
	modified:   test/test.jsx.snap
	modified:   webpack.config.js
	modified:   yarn.lock