### PR TITLE
Disable ESLint rule 'import/no-extraneous-dependencies' for demo

### DIFF
--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -1,4 +1,8 @@
 import React from 'react'
+// 'react-dom' is listed in 'devDependencies' for use with the demo of our component. We just
+// disable the 'import/no-extraneous-dependencies' rule here so ESLint doesn't complain to us when
+// we import it to get the demo working.
+// eslint-disable-next-line import/no-extraneous-dependencies
 import ReactDOM from 'react-dom'
 import Demo from './Demo'
 


### PR DESCRIPTION
PR #9 (commit 7d982f3238d2340f627f20d6cadf4e68176fc2e3) adjusted our
dependencies so that some were moved to 'peerDependencies' and some/both
were moved to 'devDependencies'. Part of this moved 'react-dom' to
'devDependencies'.

This commit disables an ESLint error for having the demo import
'react-dom' from 'devDependencies'. This ESLint error ought to have been
caught when we were doing PR #9 but I assume that I was simply running
the 'test:mocha' script instead of the 'test' script which would have
linted our files. Anyways we are fixing it now and this probably means
it's time to setup a CI/CD pipeline. :)
	modified:   demo/index.jsx