### PR TITLE
Fix (#13, #14): Render suggestions over (popover) components/elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This component also has testing which makes use of the Places library in the Goo
 
 | Prop | Type | Required | Description |
 | :--- | :--- | :---: | :--- |
-| [`renderTarget`] | Function | ✓ | Renders the components/elements that you would like to have the list of suggestions popover. |
+| `renderTarget` | Function | ✓ | Renders the components/elements that you would like to have the list of suggestions popover. |
 
 # Feedback
 This was my first open-source project that I undertook while I was teaching myself full-stack development (JS (ES6)/HTML/CSS, Node, Express, NoSQL (DynamoDB), GraphQL, React, Redux, Material-UI, etc.). I'm very interested in taking feedback to either improve my skills (i.e. correct errors :)) or to make this component more useful in general/for your use case. Please feel free to provide feedback by opening an issue or messaging me.

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ This was my first open-source project that I undertook while I was teaching myse
 * Overview and examples for the Autocomplete features in the Places library: https://developers.google.com/maps/documentation/javascript/places-autocomplete
 
 # License
-MIT
+[MIT](https://gine.mit-license.org/)

--- a/README.md
+++ b/README.md
@@ -21,9 +21,37 @@ or
 npm install mui-places-autocomplete --save --ignore-scripts
 ```
 
-Note that if you exclude the `--ignore-scripts` option when installing a package then the `prepublish` script in `package.json` is ran after installing locally. Tests are ran as part of the `prepublish` script and they will fail if you haven't yet set a Google API key to the enivronment variable `GOOGLE_API_KEY` (see setup section).
+Note that if you exclude the `--ignore-scripts` option when installing a package then the `prepublish` script in `package.json` is ran after installing locally. Tests are ran as part of the `prepublish` script and they will fail if you haven't yet set a Google API key to the enivronment variable `GOOGLE_API_KEY` (see [setup section](#setup)).
 
-# Setup
+# Demo
+**Note that you must have followed the [setup steps](#setup) to run the demo as it depends on services provided by Google.**
+
+To see a demo of this component locally clone this repository and run:
+
+```
+yarn demo
+```
+
+or
+
+```
+npm run demo
+```
+
+# Usage
+```javascript
+import React from 'react'
+import SomeCoolComponent from 'some-third-party-package'
+import MUIPlacesAutocomplete from 'mui-places-autocomplete'
+
+// Use 'renderTarget' prop to render a component/target we want the suggestions to popover
+const Example = () => (<MUIPlacesAutocomplete renderTarget={() => (<SomeCoolComponent />)} />)
+
+export default Example
+```
+
+<a name="setup"></a>
+### Setup
 This component relies on some basic setup before usage. It makes use of services provided by Google. To properly make use of the services you will need to do three things:
 1. Enable the Google Places API Web Service
 2. Enable the Google Maps JavaScript API
@@ -41,30 +69,11 @@ Be sure that you replace `YOUR_API_KEY` with the one you just created or obtaine
 
 This component also has testing which makes use of the Places library in the Google Maps JavaScript API. Rather than loading the Places library it uses a module provided by Google. It also requires an API key. This key can be provided to a file @ `test/api-key.js`. If you would like it can also be provided as an environment variable named `GOOGLE_API_KEY`.
 
-# Usage
-```javascript
-import React from 'react'
-import MUIPlacesAutocomplete from 'mui-places-autocomplete'
+### Props
 
-const Example = () => (<MUIPlacesAutocomplete />)
-
-export default Example
-```
-
-# Demo
-To see a demo of this component locally clone this repository and run:
-
-```
-yarn demo
-```
-
-or
-
-```
-npm run demo
-```
-
-Note that you must have followed the setup steps to run the demo as it depends on services provided by Google.
+| Prop | Type | Required | Description |
+| :--- | :--- | :---: | :--- |
+| [`renderTarget`] | Function | ✓ | Renders the components/elements that you would like to have the list of suggestions popover. |
 
 # Feedback
 This was my first open-source project that I undertook while I was teaching myself full-stack development (JS (ES6)/HTML/CSS, Node, Express, NoSQL (DynamoDB), GraphQL, React, Redux, Material-UI, etc.). I'm very interested in taking feedback to either improve my skills (i.e. correct errors :)) or to make this component more useful in general/for your use case. Please feel free to provide feedback by opening an issue or messaging me.

--- a/demo/Demo.jsx
+++ b/demo/Demo.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import MUIPlacesAutocomplete from './../dist'
 
-const Demo = () => (<MUIPlacesAutocomplete />)
+const Demo = () => (<MUIPlacesAutocomplete renderTarget={() => (<div />)} />)
 
 export default Demo

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "yarn test:mocha && yarn test:eslint",
-    "test:mocha": "mocha --require babel-register --require ignore-styles --require test/setup-dom.js test/test.jsx",
+    "test:mocha": "mocha --exit --require babel-register --require ignore-styles --require test/setup-dom.js test/test.jsx",
     "test:eslint": "eslint --max-warnings 0 --cache --ext .js,.jsx src test demo",
     "demo": "webpack-dev-server --config demo/webpack.config.js --content-base dist --hot",
     "build": "rm -rf dist/ && webpack",
@@ -29,8 +29,9 @@
   },
   "dependencies": {
     "autosuggest-highlight": "^3.1.0",
+    "downshift": "^1.22.5",
     "prop-types": "^15.6.0",
-    "react-autosuggest": "^9.3.2"
+    "react-popper": "^0.7.4"
   },
   "peerDependencies": {
     "material-ui": "^1.0.0-beta.21",
@@ -49,7 +50,7 @@
     "chai-jest-snapshot": "^1.3.0",
     "conventional-changelog-eslint": "^0.2.1",
     "enzyme": "^3.1.0",
-    "enzyme-adapter-react-16": "^1.0.2",
+    "enzyme-adapter-react-16": "^1.1.0",
     "enzyme-to-json": "^3.1.4",
     "eslint": "^4.9.0",
     "eslint-config-airbnb": "^16.1.0",
@@ -64,6 +65,7 @@
     "jsdom": "^11.3.0",
     "material-ui": "^1.0.0-beta.21",
     "mocha": "^4.0.1",
+    "raf": "^3.4.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "semantic-release": "^8.2.0",

--- a/src/MUIPlacesAutocomplete.jsx
+++ b/src/MUIPlacesAutocomplete.jsx
@@ -16,7 +16,6 @@ const styles = theme => ({
   container: {
     flexGrow: 1,
     position: 'relative',
-    height: 200,
   },
   suggestionsContainerOpen: {
     position: 'absolute',

--- a/src/MUIPlacesAutocomplete.jsx
+++ b/src/MUIPlacesAutocomplete.jsx
@@ -41,8 +41,15 @@ export default class MUIPlacesAutocomplete extends React.Component {
       return null
     }
 
+    // The autocomplete service can return multiple of the same predictions. This can sometimes be
+    // seen after someone selects a suggestion and starts to delete/backspace the input value which
+    // contains their selected suggestion. Here we will ensure uniqueness amongst suggestions using
+    // an ES6 Map so that we don't get duplicate key errors when we render our suggestions.
+    const uniqueSuggestions =
+      new Map(suggestions.map(({ description }) => [description, { description }]))
+
     const renderedSuggestions =
-      MUIPlacesAutocomplete.renderSuggestions(suggestions, downshiftRenderProps)
+      MUIPlacesAutocomplete.renderSuggestions([...uniqueSuggestions.values()], downshiftRenderProps)
 
     // On the <Popper> component we enable the 'inner' modifier. This is needed as Popper JS will
     // try to change the position of the popover depending on if it deems the popover is in or out
@@ -190,23 +197,9 @@ export default class MUIPlacesAutocomplete extends React.Component {
           return
         }
 
-        // The autocomplete service can return multiple of the same predictions. This can sometimes
-        // be seen after someone selects a suggestion and starts to delete/backspace the input value
-        // which contains their selected suggestion. Here we will ensure uniqueness amongst
-        // suggestions using an ES6 Map so that we don't get duplicate key errors when we render our
-        // suggestions. We decided to do this here vs. in the render functions as we only need to do
-        // it once here vs. having to do it many times due to, say, a re-render from the user
-        // mousing over the different suggestions which causes the highlighted index to change.
-        //
-        // The 'Map' constructor takes an array/other iterable object whose elements are KvPs. For
-        // arrays it contains arrays of two elements (e.g. [['someKey', 'someValue']]). Build a new
-        // array of out the predictions that provides arrays of KvPs and use it in the 'Map'
-        // constructor.
-        const suggestionsMap = new Map(predictions.map(({ description }) =>
-          [description, { description }]))
+        const suggestions = predictions.map(({ description }) => ({ description }))
 
-        // Now spread the iterable of the values of the suggestions map into a new array...
-        this.setState({ suggestions: [...suggestionsMap.values()] })
+        this.setState({ suggestions })
       },
     )
   }

--- a/src/MUIPlacesAutocomplete.jsx
+++ b/src/MUIPlacesAutocomplete.jsx
@@ -1,98 +1,130 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Autosuggest from 'react-autosuggest'
-import { MenuItem } from 'material-ui/Menu'
+import Grow from 'material-ui/transitions/Grow'
+import { MenuList, MenuItem } from 'material-ui/Menu'
+import Paper from 'material-ui/Paper'
 import TextField from 'material-ui/TextField'
-import { withStyles } from 'material-ui/styles'
+import Downshift from 'downshift'
+import { Manager, Target, Popper } from 'react-popper'
 import match from 'autosuggest-highlight/match'
 import parse from 'autosuggest-highlight/parse'
 
 import googleLogo from './images/google-logo-on-white-bg.png'
 
-// These MUI styles will be applied as the 'theme' to the <Autosuggest> component which comes with
-// no styles. For info on styling the <Autosuggest> component see:
-// https://github.com/moroshko/react-autosuggest#theme-optional
-const styles = theme => ({
-  container: {
-    flexGrow: 1,
-    position: 'relative',
-  },
-  suggestionsContainerOpen: {
-    position: 'absolute',
-    marginTop: theme.spacing.unit,
-    marginBottom: theme.spacing.unit * 3,
-    left: 0,
-    right: 0,
-  },
-  suggestion: {
-    display: 'block',
-  },
-  suggestionsList: {
-    margin: 0,
-    padding: 0,
-    listStyleType: 'none',
-  },
-  textField: {
-    width: '100%',
-  },
-})
+export default class MUIPlacesAutocomplete extends React.Component {
+  // Renders the container that will hold the suggestions and defers to other methods to render the
+  // suggestions themselves. This method should only be called if you do indeed plan on rendering
+  // the suggestions. In our case this is when 'isOpen' Downshift render prop is 'true'. Thats
+  // because the methods that are used to render the suggestions invoke the 'getItemProps' prop
+  // getter from Downshift which is an impure function. In otherwords even if you don't render the
+  // suggestions container Downshift will still think we are rendering suggestions.
+  //
+  // The 'downshiftRenderProps' argument expects an object of props that Downshift passes to the
+  // function which is set as the value of the 'render' prop on the <Downshift> component. Currently
+  // the following Downshift render props are expected on the value provided to the
+  // 'downshiftRenderProps' argument:
+  // * getItemProps - function that returns the props that ought to be applied to menu item elements
+  // that are rendered
+  // * inputValue - current value of the controlled <input> element
+  // * highlightedIndex - index of the currently highlighted menu item elements that have been
+  // rendered
+  static renderSuggestionsContainer(suggestions, downshiftRenderProps) {
+    // Return null here if there are no suggestions to render. If we don't we will show a little box
+    // that is empty and popped over the render target. This handles the case where a suggestion is
+    // selected, the input value is updated, and then the user deletes the input value. This
+    // behavior is attributed to setting the suggestions to the empty array in the
+    // 'onInputValueChange' method.
+    //
+    // Be sure we return null here before we render any of our suggestions lest we invoke the impure
+    // 'getItemProps' function.
+    if (suggestions.length === 0) {
+      return null
+    }
 
-// We export our component for testing purposes. For production use the default export from this
-// module.
-export class MUIPlacesAutocomplete extends React.Component {
-  static getSuggestionValue({ description }) {
-    return description
-  }
+    const renderedSuggestions =
+      MUIPlacesAutocomplete.renderSuggestions(suggestions, downshiftRenderProps)
 
-  static renderInputComponent({ classes, autoFocus, value, ref, ...other }) {
-    // The 'inputRef' prop takes a callback which has 1 argument which represents the DOM node for
-    // the <input> element. In this case 'ref' comes from the 'react-autowhatever' lib (which is
-    // used by the 'react-autosuggest' lib) and in this case it simply maintains a reference to the
-    // <input> DOM node for internal purposes.
+    // On the <Popper> component we enable the 'inner' modifier. This is needed as Popper JS will
+    // try to change the position of the popover depending on if it deems the popover is in or out
+    // of view. The result of enabling the 'inner' modifier means that the position of the popover
+    // won't change at all regardless of if the popover is in or out of view.
+    //
+    // Typically the <Popper> receives actual nodes for its children but in our case we opted to
+    // provided a function that creats a <div> with styles applied to it at the top-level. This
+    // <div> with the styles applied is to account for issues that arise when testing. Without it we
+    // will get the following warnings: NaN is an invalid value for the top/left css style property.
+    // This is because the DOM provider/implementation we use when testing (jsdom) doesn't return
+    // values for bounding client rect.
     return (
-      <TextField
-        className={classes.textField}
-        autoFocus={autoFocus}
-        value={value}
-        inputRef={ref}
-        InputProps={{
-          classes: { input: classes.input },
-          ...other,
-        }}
-      />
-    )
-  }
-
-  static renderSuggestionsContainer({ containerProps, children }) {
-    return (
-      <div {...containerProps}>
-        {children}
-        {children ? (
-          <div style={{ display: 'flex' }}>
-            <span style={{ flex: 1 }} />
-            <img src={googleLogo} alt="" />
+      <Popper
+        placement="top-start"
+        modifiers={({ inner: { enabled: true } })}
+        style={{ left: 0, right: 0 }}
+      >
+        {({ popperProps, restProps }) => (
+          <div
+            {...popperProps}
+            {...restProps}
+            style={{
+              ...popperProps.style,
+              top: popperProps.style.top || 0,
+              left: popperProps.style.left || 0,
+              ...restProps.style,
+            }}
+          >
+            <Grow in style={{ transformOrigin: '0 0 0' }}>
+              <Paper>
+                <MenuList>
+                  {renderedSuggestions}
+                  {renderedSuggestions.length > 0
+                      ? (
+                        <div style={{ display: 'flex' }}>
+                          <span style={{ flex: 1 }} />
+                          <img src={googleLogo} alt="" />
+                        </div>
+                        )
+                      : null}
+                </MenuList>
+              </Paper>
+            </Grow>
           </div>
-        ) : null}
-      </div>
+        )}
+      </Popper>
     )
   }
 
-  // Renders suggestions where they are highlighted based on the parts of the suggestion that match
-  // the query the user entered. This is inline with the Google Maps webapp at the time of writing.
-  // This behavior is opposite of how the Google Search bar/component/element works though.
-  static renderSuggestion({ description }, { query, isHighlighted }) {
-    // Calculate the chars to highlight in the suggestion 'description' based on the query that the
-    // user provided us. An array is returned and if any chars ought to be highlighted the array
-    // will contain a pair ([a, b]) which denote the indexes of chars to highlight (i.e.
-    // text.slice(a, b)).
-    const matches = match(description, query)
+  // Helper method to be called by 'renderSuggestionsContainer'. Returns list of rendered
+  // suggestions.
+  static renderSuggestions(suggestions, { getItemProps, inputValue, highlightedIndex }) {
+    return suggestions.map((suggestion, index) =>
+      MUIPlacesAutocomplete.renderSuggestion(
+        suggestion,
+        { getItemProps, inputValue, isHighlighted: index === highlightedIndex },
+      ))
+  }
+
+  // Helper method to be called by 'renderSuggestions'. Renders suggestions where they are
+  // highlighted based on the parts of the suggestion that match the query the user entered. This is
+  // inline with the Google Maps webapp at the time of writing. This behavior is opposite of how the
+  // Google Search bar/component/element works though.
+  static renderSuggestion({ description }, { getItemProps, inputValue, isHighlighted }) {
+    // Calculate the chars to highlight in the suggestion 'description' based on the query
+    // ('inputValue') that the user provided us. An array is returned and if any chars ought to be
+    // highlighted the array will contain a pair ([a, b]) which denote the indexes of chars to
+    // highlight (i.e. text.slice(a, b)).
+    const matches = match(description, inputValue)
 
     // Break up the suggestion 'description' based on the parts that matched. An array is returned
     // of parts where each one has an indication of if it ought to be highlighted or not.
     const parts = parse(description, matches)
 
     return (
-      <MenuItem selected={isHighlighted} component="div">
+      <MenuItem
+        {...getItemProps({ item: description })}
+        key={description}
+        selected={isHighlighted}
+        component="div"
+      >
         <div>
           {parts.map((part, index) => {
             if (part.highlight) {
@@ -119,11 +151,12 @@ export class MUIPlacesAutocomplete extends React.Component {
 
     // Control the <input> element/<Autosuggest> component and make this React component the source
     // of truth for their state.
-    this.state = { value: '', suggestions: [] }
+    this.state = {
+      suggestions: [],
+    }
 
-    this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(this)
-    this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(this)
-    this.onChange = this.onChange.bind(this)
+    this.onInputValueChange = this.onInputValueChange.bind(this)
+    this.renderAutocomplete = this.renderAutocomplete.bind(this)
   }
 
   componentDidMount() {
@@ -134,83 +167,96 @@ export class MUIPlacesAutocomplete extends React.Component {
     this.autocompleteService = new window.google.maps.places.AutocompleteService()
   }
 
-  onSuggestionsFetchRequested({ value }) {
+  // This function is called whenever Downshift detects that the input value, well, has changed.
+  // Although we only use a single argument in our function signature Downshift documents the
+  // function signature as:
+  // onInputValueChange(inputValue: string, stateAndHelpers: object)
+  onInputValueChange(inputValue) {
+    // If the inputs value is empty we can return as we will get an error if we provide the empty
+    // string when we perform a search. Set our suggestions to empty here as well so we don't render
+    // the old suggestions.
+    if (inputValue === '') {
+      this.setState({ suggestions: [] })
+      return
+    }
+
     this.autocompleteService.getPlacePredictions(
-      { input: value },
+      { input: inputValue },
       (predictions, serviceStatus) => {
-        // If the response doesn't contain a valid result then set our state as if not suggestions
+        // If the response doesn't contain a valid result then set our state as if no suggestions
         // were returned
         if (serviceStatus !== window.google.maps.places.PlacesServiceStatus.OK) {
           this.setState({ suggestions: [] })
           return
         }
 
-        const suggestions = predictions.map(({ description }) => ({ description }))
+        // The autocomplete service can return multiple of the same predictions. This can sometimes
+        // be seen after someone selects a suggestion and starts to delete/backspace the input value
+        // which contains their selected suggestion. Here we will ensure uniqueness amongst
+        // suggestions using an ES6 Map so that we don't get duplicate key errors when we render our
+        // suggestions. We decided to do this here vs. in the render functions as we only need to do
+        // it once here vs. having to do it many times due to, say, a re-render from the user
+        // mousing over the different suggestions which causes the highlighted index to change.
+        //
+        // The 'Map' constructor takes an array/other iterable object whose elements are KvPs. For
+        // arrays it contains arrays of two elements (e.g. [['someKey', 'someValue']]). Build a new
+        // array of out the predictions that provides arrays of KvPs and use it in the 'Map'
+        // constructor.
+        const suggestionsMap = new Map(predictions.map(({ description }) =>
+          [description, { description }]))
 
-        this.setState({ suggestions })
+        // Now spread the iterable of the values of the suggestions map into a new array...
+        this.setState({ suggestions: [...suggestionsMap.values()] })
       },
     )
   }
 
-  onSuggestionsClearRequested() {
-    this.setState({ suggestions: [] })
-  }
+  renderAutocomplete({
+    getInputProps,
+    getItemProps,
+    isOpen,
+    inputValue,
+    highlightedIndex,
+  }) {
+    const { suggestions } = this.state
+    const { renderTarget } = this.props
 
-  // Implementation of the 'onChange' event callback for the <input> element that is expected in the
-  // 'inputProps' prop passed to the <Autosuggest> component. The <Autosuggest> component expects
-  // the callback to have the following signature: function onChange(event, { newValue, method })
-  onChange(event, { newValue }) {
-    this.setState({ value: newValue })
+    // We set the value of 'tag' on the <Manager> component to false to allow the rendering of
+    // children instead of a specific DOM element.
+    //
+    // We only want to render our suggestions container if Downshift says we are open AND there are
+    // suggestions to actually
+    return (
+      <div>
+        <Manager tag={false}>
+          <TextField
+            {...getInputProps({
+              autoFocus: false,
+              placeholder: 'Search for a place',
+              fullWidth: true,
+            })}
+          />
+          <Target>{renderTarget()}</Target>
+          {isOpen ? MUIPlacesAutocomplete.renderSuggestionsContainer(
+                      suggestions,
+                      { getItemProps, inputValue, highlightedIndex },
+                      )
+                  : null}
+        </Manager>
+      </div>
+    )
   }
 
   render() {
-    const { suggestions, value } = this.state
-    const { classes } = this.props
-
-    // The following props are required for the <Autosuggest> component:
-    // * suggestions
-    // * getSuggestionValue
-    // * renderSuggestion
-    // * onSuggestionsFetchedRequested
-    // * onSuggestionsClearRequested
-    // * inputProps
-    //
-    // We supply the following props to give a MUI feel to our component
-    // * theme
-    // * renderInputComponent
-    // * renderSuggestionsContainer (for the Google logo)
-    // * renderSuggestion
     return (
-      <Autosuggest
-        suggestions={suggestions}
-        getSuggestionValue={MUIPlacesAutocomplete.getSuggestionValue}
-        renderInputComponent={MUIPlacesAutocomplete.renderInputComponent}
-        renderSuggestionsContainer={MUIPlacesAutocomplete.renderSuggestionsContainer}
-        renderSuggestion={MUIPlacesAutocomplete.renderSuggestion}
-        onSuggestionsFetchRequested={this.onSuggestionsFetchRequested}
-        onSuggestionsClearRequested={this.onSuggestionsClearRequested}
-        inputProps={{
-          classes,
-          value,
-          onChange: this.onChange,
-          autoFocus: true,
-          placeholder: 'Search for a place',
-        }}
-        theme={{
-          container: classes.container,
-          suggestionsContainerOpen: classes.suggestionsContainerOpen,
-          suggestionsList: classes.suggestionsList,
-          suggestion: classes.suggestion,
-        }}
+      <Downshift
+        onInputValueChange={this.onInputValueChange}
+        render={this.renderAutocomplete}
       />
     )
   }
 }
 
 MUIPlacesAutocomplete.propTypes = {
-  classes: PropTypes.object.isRequired,
+  renderTarget: PropTypes.func.isRequired,
 }
-
-const MUIPlacesAutocompleteHOC = withStyles(styles)(MUIPlacesAutocomplete)
-
-export default MUIPlacesAutocompleteHOC

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-import MUIPlacesAutocompleteHOC from './MUIPlacesAutocomplete'
+import MUIPlacesAutocomplete from './MUIPlacesAutocomplete'
 
-export default MUIPlacesAutocompleteHOC
+export default MUIPlacesAutocomplete

--- a/test/setup-dom.js
+++ b/test/setup-dom.js
@@ -13,17 +13,15 @@
 // Note that it is important that your tests using the global DOM APIs don't have "leaky"
 // side-effects which could change the results of other tests.
 //
-// For more info see: http://airbnb.io/enzyme/docs/guides/jsdom.html
-
+// The DOM was setup based on the guideance that Enzyme gives as well as how MUI sets up their DOM
+// for testing purposes. For more info see:
+// * http://airbnb.io/enzyme/docs/guides/jsdom.html
+// * https://github.com/mui-org/material-ui/blob/3fdf302d44594c68b0700843aa79793525ad0f7c/test/utils/createDOM.js
 import { JSDOM } from 'jsdom'
+import Node from 'jsdom/lib/jsdom/living/node-document-position'
+import { polyfill as rafPolyfill } from 'raf'
 
-const copyProps = (src, target) => {
-  const props = Object.getOwnPropertyNames(src)
-    .filter(prop => typeof target[prop] === 'undefined')
-    .map(prop => Object.getOwnPropertyDescriptor(src, prop))
-
-  Object.defineProperties(target, props)
-}
+const KEYS = ['HTMLElement']
 
 const jsdom = new JSDOM(`
   <!DOCTYPE html>
@@ -32,10 +30,46 @@ const jsdom = new JSDOM(`
   </html>
 `)
 
-const { window } = jsdom
+global.window = jsdom.window
+global.document = undefined
+global.Node = Node
 
-global.window = window
-global.document = window.document
-global.navigator = { userAgent: 'node.js' }
+// This ought to add 'getComputedStyle()' which is used by PopperJS to the 'global' object
+Object.keys(jsdom.window).forEach((property) => {
+  if (typeof global[property] === 'undefined') {
+    global[property] = jsdom.window[property]
+  }
+})
 
-copyProps(window, global)
+// PopperJS isn't going to work with jsdom out of the box as it relies on real browser DOM APIs to
+// work: https://github.com/FezVrasta/popper.js/issues/478#issuecomment-341377821
+//
+// One of those APIs is 'createRange' which PopperJS uses when finding the offset of the parent of
+// some nodes. Although jsdom did provide the API it doesn't anymore:
+// https://github.com/tmpvar/jsdom/blame/4c7698f760fc64f20b2a0ddff450eddbdd193176/lib/jsdom/living/nodes/Document.webidl#L39
+//
+// Here we mock the API ourselves. Note that typically the property
+// 'commonAncestorContainer.ownerDocument' on the returned object isn't always the 'document'. But
+// for testing purposes this is okay as it merely matches what PopperJS was doing in the past when
+// they returned an element for the offset parent. For reference see:
+// https://github.com/FezVrasta/popper.js/commit/5e84ac0240bc9551143a8d6647b39eaf02d212a8
+global.document.createRange = () => ({
+  setStart: () => {},
+  setEnd: () => {},
+  commonAncestorContainer: {
+    nodeName: 'BODY',
+    ownerDocument: document,
+  },
+})
+
+global.navigator = {
+  userAgent: 'node.js',
+  appVersion: global.navigator.appVersion,
+}
+
+KEYS.forEach((key) => {
+  global[key] = window[key]
+})
+
+// 'requestAnimationFrame' is used by React
+rafPolyfill(global)

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -13,7 +13,7 @@ import toJson from 'enzyme-to-json'
 import React from 'react'
 
 // Code under test
-import { MUIPlacesAutocomplete } from './../src/MUIPlacesAutocomplete'
+import MUIPlacesAutocomplete from './../src'
 
 // Supporting code
 import getACServiceClassDef from './testHelper'
@@ -42,6 +42,21 @@ describe('React component test: <MUIPlacesAutocomplete>', function () {
     // component that will be under test
     let mpaWrapper = null
 
+    // Helper function to get the JSON of the <MenuList> component in our <MUIPlacesAutocomplete>
+    // component. Useful for snapshot testing only the components that we are in charge of
+    // rendering (i.e. the suggestions).
+    const getMenuListJSON = () => {
+      expect(mpaWrapper).to.not.be.null
+
+      const mlWrapper = mpaWrapper.find('MenuList')
+
+      // Make sure we have a wrapper around a <MenuList> and only a single <MenuList>
+      expect(mlWrapper).to.not.be.null
+      expect(mlWrapper.length).to.equal(1)
+
+      return toJson(mlWrapper)
+    }
+
     before('"Load" the Google Maps JavaScript API on \'window\'', function () {
       // These tests depend on a DOM to be setup for more indepth tests that either do full DOM
       // rendering or for leveraging DOM APIs. At this point we presume that the DOM has been setup
@@ -49,7 +64,7 @@ describe('React component test: <MUIPlacesAutocomplete>', function () {
       expect(global.window).to.exist
 
       // The <MUIPlacesAutocomplete> component expects the Google Maps JavaScript API to be loaded
-      // in the 'window' object. Since we aren't loading it we mock our the API and add it to the
+      // in the 'window' object. Since we aren't loading it we mock out the API and add it to the
       // 'window' object.
       global.window.google = {
         maps: {
@@ -70,77 +85,93 @@ describe('React component test: <MUIPlacesAutocomplete>', function () {
     })
 
     beforeEach('Setup Enzyme wrapper', function () {
-      // Since we aren't testing the MUIPlacesAutocomplete HOC (see MUI 'withStyles()') we provide
-      // an empty object for the MUI styling/classes that would normally get applied so we don't try
-      // to reference an undefined prop.
-      mpaWrapper = mount(<MUIPlacesAutocomplete classes={{ }} />)
+      mpaWrapper = mount(<MUIPlacesAutocomplete renderTarget={() => (<div />)} />)
 
       expect(mpaWrapper).to.not.be.null
     })
 
     it('Initial state', function () {
-      expect(mpaWrapper.state().value).to.exist
-      expect(mpaWrapper.state().value).to.be.empty
       expect(mpaWrapper.state().suggestions).to.exist
       expect(mpaWrapper.state().suggestions).to.be.empty
 
-      // Protect us from forgetting to update this test if we add an additional key to the
-      // components state. We currently only expect the 'value' and 'suggestions' key...
-      expect(Object.keys(mpaWrapper.state()).length).to.equal(2)
+      // Protect us from forgetting to update this test if we add an additional key(s) to the
+      // components state. We currently only expect the 'suggestions' key...
+      expect(Object.keys(mpaWrapper.state()).length).to.equal(1)
 
-      // We snapshot the initial state to provide visibility to any changes we have made to our
-      // component...
-      expect(toJson(mpaWrapper)).to.matchSnapshot()
+      // We don't snapshot test our component since 1) the <Downshift>/<Popper> components that our
+      // <MUIPlacesAutocomplete> component composes is massive and takes long to diff the
+      // serializations and 2) our container ought not be open anyway. We can verify that the
+      // suggestions container isn't open by searching for the <MenuList> component.
+      expect(mpaWrapper.find('MenuList').length).to.equal(0)
     })
 
     it('Suggestions rendered from \'suggestions\' state', function () {
-      // Provide a search input and a suggestion to our state so a suggestion is rendered
-      mpaWrapper.setState({
-        value: searchInputValue,
-        suggestions: [{ description: 'Bellingham, WA, United States' }],
-      })
-      mpaWrapper.find('input').simulate('focus')
+      // To get suggestions to be rendered first simulate an input onChange event which will cause
+      // <Downshift> to believe that our autocomplete/dropdown is open...
+      mpaWrapper.find('input').simulate('change', { target: { value: searchInputValue } })
 
-      expect(mpaWrapper.state().suggestions.length).to.equal(1)
-      expect(mpaWrapper.find('MenuItem').length).to.equal(mpaWrapper.state().suggestions.length)
+      // Second set the state of our component to provide suggestions as if they were returned from
+      // the Google AutocompleteService...
+      const expectedSuggestion = { description: 'Bellingham, WA, United States' }
+      const expectedSuggestionCount = 1
 
-      expect(toJson(mpaWrapper)).to.matchSnapshot()
+      mpaWrapper.setState({ suggestions: [expectedSuggestion] })
+
+      // Now check that our suggestions are rendered...
+      expect(mpaWrapper.find('MenuItem').length).to.equal(expectedSuggestionCount)
+      expect(mpaWrapper.find('MenuItem').text()).to.equal(expectedSuggestion.description)
+
+      // Snapshot test only the <MenuList> of our suggestions as the <Downshift>/<Popper> components
+      // that our <MUIPlacesAutocomplete> component composes is massive and takes to long to diff
+      // the serializations.
+      expect(getMenuListJSON()).to.matchSnapshot()
     })
 
     it('Empty input renders no suggestions after previous ones rendered', function () {
-      // Make sure we aren't asserting an empty list of suggestions in the first place after
-      // focusing the 'input' element...
-      mpaWrapper.setState({
-        value: searchInputValue,
-        suggestions: [{ description: 'Bellingham, WA, United States' }],
-      })
-      mpaWrapper.find('input').simulate('focus')
+      // To get suggestions to be rendered first simulate an input onChange event which will cause
+      // <Downshift> to believe that our autocomplete/dropdown is open...
+      mpaWrapper.find('input').simulate('change', { target: { value: searchInputValue } })
 
-      expect(mpaWrapper.state().suggestions.length).to.equal(1)
-      expect(mpaWrapper.find('MenuItem').length).to.equal(mpaWrapper.state().suggestions.length)
+      // Second set the start of our component to provide suggestions as if they were returned from
+      // the Google AutocompleteService...
+      const expectedSuggestion = { description: 'Bellingham, WA, United States' }
+      let expectedSuggestionCount = 1
 
-      // Now check that we no longer render suggestions on empty input...
+      mpaWrapper.setState({ suggestions: [expectedSuggestion] })
+
+      // Now check that our suggestions are rendered...
+      expect(mpaWrapper.find('MenuItem').length).to.equal(expectedSuggestionCount)
+      expect(mpaWrapper.find('MenuItem').text()).to.equal(expectedSuggestion.description)
+
+      // Now clear the input and check that no suggestions are rendered...
       mpaWrapper.find('input').simulate('change', { target: { value: '' } })
 
-      expect(mpaWrapper.state().value).to.be.empty
-      expect(mpaWrapper.state().suggestions).to.be.empty
-      expect(mpaWrapper.find('MenuItem').length).to.equal(0)
+      expectedSuggestionCount = 0
 
-      expect(toJson(mpaWrapper)).to.matchSnapshot()
+      expect(mpaWrapper.find('MenuItem').length).to.equal(expectedSuggestionCount)
+
+      // We don't snapshot test since our suggestions container ought not be open. We can verify it
+      // isn't by searching for the <MenuList> component
+      expect(mpaWrapper.find('MenuList').length).to.equal(0)
     })
 
     it('Google logo is present in a populated list of suggestions', function () {
-      // Provide a search input and a suggestion to our state so we can render the suggestions
-      // container which will have the Google Logo in a single <img> element
-      mpaWrapper.setState({
-        value: searchInputValue,
-        suggestions: [{ description: 'Bellingham, WA, United States' }],
-      })
-      mpaWrapper.find('input').simulate('focus')
+      // To get suggestions to be rendered first simulate an input onChange event which will cause
+      // <Downshift> to believe that our autocomplete/dropdown is open...
+      mpaWrapper.find('input').simulate('change', { target: { value: searchInputValue } })
 
+      // Second set the start of our component to provide suggestions as if they were returned from
+      // the Google AutocompleteService...
+
+      mpaWrapper.setState({ suggestions: [{ description: 'Bellingham, WA, United States' }] })
+
+      // Now check that our image is rendered...
       expect(mpaWrapper.find('img').length).to.equal(1)
 
-      expect(toJson(mpaWrapper)).to.matchSnapshot()
+      // Snapshot test only the <MenuList> of our suggestions as the <Downshift>/<Popper> components
+      // that our <MUIPlacesAutocomplete> component composes is massive and takes to long to diff
+      // the serializations.
+      expect(getMenuListJSON()).to.matchSnapshot()
     })
   })
 
@@ -154,7 +185,6 @@ describe('React component test: <MUIPlacesAutocomplete>', function () {
       // that suggestions have been populated and signal that we have completed the test.
       const testCallback = () => {
         try {
-          expect(mpaWrapper.state().value).to.equal(searchInputValue)
           expect(mpaWrapper.state().suggestions).to.not.be.empty
         } catch (e) {
           done(e)
@@ -187,10 +217,11 @@ describe('React component test: <MUIPlacesAutocomplete>', function () {
 
       // Now mount our component to make use of our mock API when we send a 'change' event on our
       // 'input' element
-      mpaWrapper = mount(<MUIPlacesAutocomplete classes={{ }} />)
+      mpaWrapper = mount(<MUIPlacesAutocomplete renderTarget={() => (<div />)} />)
 
       const inputWrapper = mpaWrapper.find('input')
 
+      inputWrapper.simulate('focus')
       inputWrapper.simulate('change', { target: { value: searchInputValue } })
     })
   })

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -15,7 +15,7 @@ import React from 'react'
 // Code under test
 import MUIPlacesAutocomplete from './../src'
 
-// Supporting code
+// Supporting test code
 import getACServiceClassDef from './testHelper'
 
 // Configure Chai to work with Jest
@@ -155,6 +155,28 @@ describe('React component test: <MUIPlacesAutocomplete>', function () {
       expect(mpaWrapper.find('MenuList').length).to.equal(0)
     })
 
+    it('Duplicate suggestions aren\'t rendered', function () {
+      // To get suggestions to be rendered first simulate an input onChange event which will cause
+      // <Downshift> to believe that our autocomplete/dropdown is open...
+      mpaWrapper.find('input').simulate('change', { target: { value: searchInputValue } })
+
+      // Second set the state of our component to provide duplicate suggestions as if they were
+      // returned from the Google AutocompleteService...
+      const expectedSuggestion = { description: 'Bellingham, WA, United States' }
+      const expectedSuggestionCount = 1
+
+      mpaWrapper.setState({ suggestions: [expectedSuggestion, expectedSuggestion] })
+
+      // Now check that our suggestions are uniquely rendered...
+      expect(mpaWrapper.find('MenuItem').length).to.equal(expectedSuggestionCount)
+      expect(mpaWrapper.find('MenuItem').text()).to.equal(expectedSuggestion.description)
+
+      // Snapshot test only the <MenuList> of our suggestions as the <Downshift>/<Popper> components
+      // that our <MUIPlacesAutocomplete> component composes is massive and takes to long to diff
+      // the serializations.
+      expect(getMenuListJSON()).to.matchSnapshot()
+    })
+
     it('Google logo is present in a populated list of suggestions', function () {
       // To get suggestions to be rendered first simulate an input onChange event which will cause
       // <Downshift> to believe that our autocomplete/dropdown is open...
@@ -182,7 +204,7 @@ describe('React component test: <MUIPlacesAutocomplete>', function () {
       // Find the 'input' element so we can simulate an event for changing the input which will
       // cause our component to get place predictions with the Google Maps API and ultimately update
       // its state with place suggestions. Before doing so setup our test callback so we can assert
-      // that suggestions have been populated and signal that we have completed the test.
+      // that suggestions have been populated.
       const testCallback = () => {
         try {
           expect(mpaWrapper.state().suggestions).to.not.be.empty

--- a/test/test.jsx.snap
+++ b/test/test.jsx.snap
@@ -1,1577 +1,485 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for given application state: Empty input renders no suggestions after previous ones rendered 1`] = `
-<MUIPlacesAutocomplete
-  classes={Object {}}
->
-  <Autosuggest
-    alwaysRenderSuggestions={false}
-    focusInputOnSuggestionClick={true}
-    getSuggestionValue={[Function]}
-    highlightFirstSuggestion={false}
-    id="1"
-    inputProps={
-      Object {
-        "autoFocus": true,
-        "classes": Object {},
-        "onChange": [Function],
-        "placeholder": "Search for a place",
-        "value": "",
-      }
-    }
-    multiSection={false}
-    onSuggestionsClearRequested={[Function]}
-    onSuggestionsFetchRequested={[Function]}
-    renderInputComponent={[Function]}
-    renderSuggestion={[Function]}
-    renderSuggestionsContainer={[Function]}
-    shouldRenderSuggestions={[Function]}
-    suggestions={Array []}
-    theme={
-      Object {
-        "container": undefined,
-        "suggestion": undefined,
-        "suggestionsContainerOpen": undefined,
-        "suggestionsList": undefined,
-      }
-    }
-  >
-    <Autowhatever
-      getSectionItems={[Function]}
-      highlightedItemIndex={null}
-      highlightedSectionIndex={null}
-      id="1"
-      inputProps={
-        Object {
-          "autoFocus": true,
-          "classes": Object {},
-          "onBlur": [Function],
-          "onChange": [Function],
-          "onFocus": [Function],
-          "onKeyDown": [Function],
-          "placeholder": "Search for a place",
-          "value": "",
-        }
-      }
-      itemProps={[Function]}
-      items={Array []}
-      multiSection={false}
-      renderInputComponent={[Function]}
-      renderItem={[Function]}
-      renderItemData={
-        Object {
-          "query": "",
-        }
-      }
-      renderItemsContainer={[Function]}
-      renderSectionTitle={[Function]}
-      theme={
-        Object {
-          "container": undefined,
-          "item": undefined,
-          "itemsContainerOpen": undefined,
-          "itemsList": undefined,
-        }
-      }
-    >
-      <div
-        key="react-autowhatever-1-container"
-        style={Object {}}
-      >
-        <TextField
-          InputProps={
-            Object {
-              "aria-activedescendant": null,
-              "aria-autocomplete": "list",
-              "aria-expanded": false,
-              "aria-haspopup": false,
-              "aria-owns": "react-autowhatever-1",
-              "autoComplete": "off",
-              "classes": Object {
-                "input": undefined,
-              },
-              "key": "react-autowhatever-1-input",
-              "onBlur": [Function],
-              "onChange": [Function],
-              "onFocus": [Function],
-              "onKeyDown": [Function],
-              "placeholder": "Search for a place",
-              "role": "combobox",
-              "style": Object {},
-              "type": "text",
-            }
-          }
-          autoFocus={true}
-          className={undefined}
-          inputRef={[Function]}
-          required={false}
-          select={false}
-          value=""
-        >
-          <withStyles(FormControl)
-            className={undefined}
-            error={undefined}
-            fullWidth={undefined}
-            required={false}
-          >
-            <FormControl
-              className={undefined}
-              classes={
-                Object {
-                  "fullWidth": "MuiFormControl-fullWidth-4",
-                  "marginDense": "MuiFormControl-marginDense-3",
-                  "marginNormal": "MuiFormControl-marginNormal-2",
-                  "root": "MuiFormControl-root-1",
-                }
-              }
-              component="div"
-              disabled={false}
-              error={false}
-              fullWidth={false}
-              margin="none"
-              required={false}
-            >
-              <div
-                className="MuiFormControl-root-1"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                required={false}
-              >
-                <withStyles(Input)
-                  aria-activedescendant={null}
-                  aria-autocomplete="list"
-                  aria-expanded={false}
-                  aria-haspopup={false}
-                  aria-owns="react-autowhatever-1"
-                  autoComplete="off"
-                  autoFocus={true}
-                  className={undefined}
-                  classes={
-                    Object {
-                      "input": undefined,
-                    }
-                  }
-                  defaultValue={undefined}
-                  disabled={undefined}
-                  id={undefined}
-                  inputProps={undefined}
-                  inputRef={[Function]}
-                  key="react-autowhatever-1-input"
-                  multiline={undefined}
-                  name={undefined}
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  placeholder="Search for a place"
-                  role="combobox"
-                  rows={undefined}
-                  rowsMax={undefined}
-                  style={Object {}}
-                  type="text"
-                  value=""
-                >
-                  <Input
-                    aria-activedescendant={null}
-                    aria-autocomplete="list"
-                    aria-expanded={false}
-                    aria-haspopup={false}
-                    aria-owns="react-autowhatever-1"
-                    autoComplete="off"
-                    autoFocus={true}
-                    className={undefined}
-                    classes={
-                      Object {
-                        "disabled": "MuiInput-disabled-9",
-                        "error": "MuiInput-error-8",
-                        "focused": "MuiInput-focused-10",
-                        "formControl": "MuiInput-formControl-6",
-                        "fullWidth": "MuiInput-fullWidth-13",
-                        "inkbar": "MuiInput-inkbar-7",
-                        "input": "MuiInput-input-14",
-                        "inputDense": "MuiInput-inputDense-15",
-                        "inputDisabled": "MuiInput-inputDisabled-16",
-                        "inputMultiline": "MuiInput-inputMultiline-18",
-                        "inputSearch": "MuiInput-inputSearch-19",
-                        "inputSingleline": "MuiInput-inputSingleline-17",
-                        "multiline": "MuiInput-multiline-12",
-                        "root": "MuiInput-root-5",
-                        "underline": "MuiInput-underline-11",
-                      }
-                    }
-                    defaultValue={undefined}
-                    disableUnderline={false}
-                    disabled={undefined}
-                    fullWidth={false}
-                    id={undefined}
-                    inputProps={undefined}
-                    inputRef={[Function]}
-                    multiline={false}
-                    name={undefined}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    placeholder="Search for a place"
-                    role="combobox"
-                    rows={undefined}
-                    rowsMax={undefined}
-                    style={Object {}}
-                    type="text"
-                    value=""
-                  >
-                    <div
-                      aria-activedescendant={null}
-                      aria-autocomplete="list"
-                      aria-expanded={false}
-                      aria-haspopup={false}
-                      aria-owns="react-autowhatever-1"
-                      className="MuiInput-root-5 MuiInput-focused-10 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-11"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      role="combobox"
-                      style={Object {}}
-                    >
-                      <input
-                        autoComplete="off"
-                        autoFocus={true}
-                        className="MuiInput-input-14 MuiInput-inputSingleline-17"
-                        defaultValue={undefined}
-                        disabled={false}
-                        id={undefined}
-                        name={undefined}
-                        onChange={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={undefined}
-                        placeholder="Search for a place"
-                        readOnly={undefined}
-                        required={undefined}
-                        rows={undefined}
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </Input>
-                </withStyles(Input)>
-              </div>
-            </FormControl>
-          </withStyles(FormControl)>
-        </TextField>
-        <div
-          id="react-autowhatever-1"
-          key="react-autowhatever-1-items-container"
-          style={Object {}}
-        />
-      </div>
-    </Autowhatever>
-  </Autosuggest>
-</MUIPlacesAutocomplete>
-`;
-
 exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for given application state: Google logo is present in a populated list of suggestions 1`] = `
-<MUIPlacesAutocomplete
-  classes={Object {}}
->
-  <Autosuggest
-    alwaysRenderSuggestions={false}
-    focusInputOnSuggestionClick={true}
-    getSuggestionValue={[Function]}
-    highlightFirstSuggestion={false}
-    id="1"
-    inputProps={
-      Object {
-        "autoFocus": true,
-        "classes": Object {},
-        "onChange": [Function],
-        "placeholder": "Search for a place",
-        "value": "Bellingham",
-      }
-    }
-    multiSection={false}
-    onSuggestionsClearRequested={[Function]}
-    onSuggestionsFetchRequested={[Function]}
-    renderInputComponent={[Function]}
-    renderSuggestion={[Function]}
-    renderSuggestionsContainer={[Function]}
-    shouldRenderSuggestions={[Function]}
-    suggestions={
-      Array [
-        Object {
-          "description": "Bellingham, WA, United States",
-        },
-      ]
-    }
-    theme={
-      Object {
-        "container": undefined,
-        "suggestion": undefined,
-        "suggestionsContainerOpen": undefined,
-        "suggestionsList": undefined,
-      }
-    }
+<MenuList>
+  <withStyles(List)
+    className={undefined}
+    onBlur={[Function]}
+    onKeyDown={[Function]}
+    role="menu"
+    rootRef={[Function]}
   >
-    <Autowhatever
-      getSectionItems={[Function]}
-      highlightedItemIndex={null}
-      highlightedSectionIndex={null}
-      id="1"
-      inputProps={
+    <List
+      className={undefined}
+      classes={
         Object {
-          "autoFocus": true,
-          "classes": Object {},
-          "onBlur": [Function],
-          "onChange": [Function],
-          "onFocus": [Function],
-          "onKeyDown": [Function],
-          "placeholder": "Search for a place",
-          "value": "Bellingham",
+          "dense": "MuiList-dense-49",
+          "padding": "MuiList-padding-48",
+          "root": "MuiList-root-47",
+          "subheader": "MuiList-subheader-50",
         }
       }
-      itemProps={[Function]}
-      items={
-        Array [
-          Object {
-            "description": "Bellingham, WA, United States",
-          },
-        ]
-      }
-      multiSection={false}
-      renderInputComponent={[Function]}
-      renderItem={[Function]}
-      renderItemData={
-        Object {
-          "query": "Bellingham",
-        }
-      }
-      renderItemsContainer={[Function]}
-      renderSectionTitle={[Function]}
-      theme={
-        Object {
-          "container": undefined,
-          "item": undefined,
-          "itemsContainerOpen": undefined,
-          "itemsList": undefined,
-        }
-      }
+      component="ul"
+      dense={false}
+      disablePadding={false}
+      onBlur={[Function]}
+      onKeyDown={[Function]}
+      role="menu"
+      rootRef={[Function]}
     >
-      <div
-        key="react-autowhatever-1-container"
-        style={Object {}}
+      <ul
+        className="MuiList-root-47 MuiList-padding-48"
+        onBlur={[Function]}
+        onKeyDown={[Function]}
+        role="menu"
       >
-        <TextField
-          InputProps={
-            Object {
-              "aria-activedescendant": null,
-              "aria-autocomplete": "list",
-              "aria-expanded": true,
-              "aria-haspopup": true,
-              "aria-owns": "react-autowhatever-1",
-              "autoComplete": "off",
-              "classes": Object {
-                "input": undefined,
-              },
-              "key": "react-autowhatever-1-input",
-              "onBlur": [Function],
-              "onChange": [Function],
-              "onFocus": [Function],
-              "onKeyDown": [Function],
-              "placeholder": "Search for a place",
-              "role": "combobox",
-              "style": Object {},
-              "type": "text",
-            }
-          }
-          autoFocus={true}
-          className={undefined}
-          inputRef={[Function]}
-          required={false}
-          select={false}
-          value="Bellingham"
+        <withStyles(MenuItem)
+          component="div"
+          id="downshift-1-item-0"
+          key=".0:$Bellingham, WA, United States"
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          selected={false}
+          tabIndex={-1}
         >
-          <withStyles(FormControl)
-            className={undefined}
-            error={undefined}
-            fullWidth={undefined}
-            required={false}
-          >
-            <FormControl
-              className={undefined}
-              classes={
-                Object {
-                  "fullWidth": "MuiFormControl-fullWidth-4",
-                  "marginDense": "MuiFormControl-marginDense-3",
-                  "marginNormal": "MuiFormControl-marginNormal-2",
-                  "root": "MuiFormControl-root-1",
-                }
+          <MenuItem
+            classes={
+              Object {
+                "root": "MuiMenuItem-root-51",
+                "selected": "MuiMenuItem-selected-52",
               }
+            }
+            component="div"
+            id="downshift-1-item-0"
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            role="menuitem"
+            selected={false}
+            tabIndex={-1}
+          >
+            <withStyles(ListItem)
+              button={true}
+              className="MuiMenuItem-root-51"
               component="div"
-              disabled={false}
-              error={false}
-              fullWidth={false}
-              margin="none"
-              required={false}
+              id="downshift-1-item-0"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              role="menuitem"
+              tabIndex={-1}
             >
-              <div
-                className="MuiFormControl-root-1"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                required={false}
-              >
-                <withStyles(Input)
-                  aria-activedescendant={null}
-                  aria-autocomplete="list"
-                  aria-expanded={true}
-                  aria-haspopup={true}
-                  aria-owns="react-autowhatever-1"
-                  autoComplete="off"
-                  autoFocus={true}
-                  className={undefined}
-                  classes={
-                    Object {
-                      "input": undefined,
-                    }
+              <ListItem
+                button={true}
+                className="MuiMenuItem-root-51"
+                classes={
+                  Object {
+                    "button": "MuiListItem-button-61",
+                    "container": "MuiListItem-container-54",
+                    "default": "MuiListItem-default-56",
+                    "dense": "MuiListItem-dense-57",
+                    "disabled": "MuiListItem-disabled-58",
+                    "divider": "MuiListItem-divider-59",
+                    "gutters": "MuiListItem-gutters-60",
+                    "keyboardFocused": "MuiListItem-keyboardFocused-55",
+                    "root": "MuiListItem-root-53",
+                    "secondaryAction": "MuiListItem-secondaryAction-62",
                   }
-                  defaultValue={undefined}
-                  disabled={undefined}
-                  id={undefined}
-                  inputProps={undefined}
-                  inputRef={[Function]}
-                  key="react-autowhatever-1-input"
-                  multiline={undefined}
-                  name={undefined}
-                  onBlur={[Function]}
-                  onChange={[Function]}
+                }
+                component="div"
+                dense={false}
+                disableGutters={false}
+                disabled={false}
+                divider={false}
+                id="downshift-1-item-0"
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                role="menuitem"
+                tabIndex={-1}
+              >
+                <withStyles(ButtonBase)
+                  className="MuiListItem-root-53 MuiListItem-gutters-60 MuiListItem-button-61 MuiListItem-default-56 MuiMenuItem-root-51"
+                  component="div"
+                  disabled={false}
+                  id="downshift-1-item-0"
+                  keyboardFocusedClassName="MuiListItem-keyboardFocused-55"
+                  onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  placeholder="Search for a place"
-                  role="combobox"
-                  rows={undefined}
-                  rowsMax={undefined}
-                  style={Object {}}
-                  type="text"
-                  value="Bellingham"
+                  onMouseEnter={[Function]}
+                  role="menuitem"
+                  tabIndex={-1}
                 >
-                  <Input
-                    aria-activedescendant={null}
-                    aria-autocomplete="list"
-                    aria-expanded={true}
-                    aria-haspopup={true}
-                    aria-owns="react-autowhatever-1"
-                    autoComplete="off"
-                    autoFocus={true}
-                    className={undefined}
+                  <ButtonBase
+                    centerRipple={false}
+                    className="MuiListItem-root-53 MuiListItem-gutters-60 MuiListItem-button-61 MuiListItem-default-56 MuiMenuItem-root-51"
                     classes={
                       Object {
-                        "disabled": "MuiInput-disabled-9",
-                        "error": "MuiInput-error-8",
-                        "focused": "MuiInput-focused-10",
-                        "formControl": "MuiInput-formControl-6",
-                        "fullWidth": "MuiInput-fullWidth-13",
-                        "inkbar": "MuiInput-inkbar-7",
-                        "input": "MuiInput-input-14",
-                        "inputDense": "MuiInput-inputDense-15",
-                        "inputDisabled": "MuiInput-inputDisabled-16",
-                        "inputMultiline": "MuiInput-inputMultiline-18",
-                        "inputSearch": "MuiInput-inputSearch-19",
-                        "inputSingleline": "MuiInput-inputSingleline-17",
-                        "multiline": "MuiInput-multiline-12",
-                        "root": "MuiInput-root-5",
-                        "underline": "MuiInput-underline-11",
+                        "disabled": "MuiButtonBase-disabled-64",
+                        "root": "MuiButtonBase-root-63",
                       }
                     }
-                    defaultValue={undefined}
-                    disableUnderline={false}
-                    disabled={undefined}
-                    fullWidth={false}
-                    id={undefined}
-                    inputProps={undefined}
-                    inputRef={[Function]}
-                    multiline={false}
-                    name={undefined}
-                    onBlur={[Function]}
-                    onChange={[Function]}
+                    component="div"
+                    disableRipple={false}
+                    disabled={false}
+                    focusRipple={false}
+                    id="downshift-1-item-0"
+                    keyboardFocusedClassName="MuiListItem-keyboardFocused-55"
+                    onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    placeholder="Search for a place"
-                    role="combobox"
-                    rows={undefined}
-                    rowsMax={undefined}
-                    style={Object {}}
-                    type="text"
-                    value="Bellingham"
+                    onMouseEnter={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                    type="button"
                   >
                     <div
-                      aria-activedescendant={null}
-                      aria-autocomplete="list"
-                      aria-expanded={true}
-                      aria-haspopup={true}
-                      aria-owns="react-autowhatever-1"
-                      className="MuiInput-root-5 MuiInput-focused-10 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-11"
+                      className="MuiButtonBase-root-63 MuiListItem-root-53 MuiListItem-gutters-60 MuiListItem-button-61 MuiListItem-default-56 MuiMenuItem-root-51"
+                      disabled={false}
+                      id="downshift-1-item-0"
                       onBlur={[Function]}
+                      onClick={[Function]}
                       onFocus={[Function]}
-                      role="combobox"
-                      style={Object {}}
-                    >
-                      <input
-                        autoComplete="off"
-                        autoFocus={true}
-                        className="MuiInput-input-14 MuiInput-inputSingleline-17"
-                        defaultValue={undefined}
-                        disabled={false}
-                        id={undefined}
-                        name={undefined}
-                        onChange={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={undefined}
-                        placeholder="Search for a place"
-                        readOnly={undefined}
-                        required={undefined}
-                        rows={undefined}
-                        type="text"
-                        value="Bellingham"
-                      />
-                    </div>
-                  </Input>
-                </withStyles(Input)>
-              </div>
-            </FormControl>
-          </withStyles(FormControl)>
-        </TextField>
-        <div
-          id="react-autowhatever-1"
-          key="react-autowhatever-1-items-container"
-          style={Object {}}
-        >
-          <ItemsList
-            getItemId={[Function]}
-            highlightedItemIndex={null}
-            itemProps={[Function]}
-            items={
-              Array [
-                Object {
-                  "description": "Bellingham, WA, United States",
-                },
-              ]
-            }
-            keyPrefix="react-autowhatever-1-"
-            onHighlightedItemChange={[Function]}
-            renderItem={[Function]}
-            renderItemData={
-              Object {
-                "query": "Bellingham",
-              }
-            }
-            sectionIndex={null}
-            theme={[Function]}
-          >
-            <ul
-              key="react-autowhatever-1-items-list"
-              role="listbox"
-              style={Object {}}
-            >
-              <Item
-                data-section-index={null}
-                data-suggestion-index={0}
-                id="react-autowhatever-1--item-0"
-                isHighlighted={false}
-                item={
-                  Object {
-                    "description": "Bellingham, WA, United States",
-                  }
-                }
-                itemIndex={0}
-                key="react-autowhatever-1-item-0"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchStart={[Function]}
-                renderItem={[Function]}
-                renderItemData={
-                  Object {
-                    "query": "Bellingham",
-                  }
-                }
-                sectionIndex={null}
-                style={Object {}}
-              >
-                <li
-                  data-section-index={null}
-                  data-suggestion-index={0}
-                  id="react-autowhatever-1--item-0"
-                  onClick={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onTouchStart={[Function]}
-                  role="option"
-                  style={Object {}}
-                >
-                  <withStyles(MenuItem)
-                    component="div"
-                    selected={false}
-                  >
-                    <MenuItem
-                      classes={
-                        Object {
-                          "root": "MuiMenuItem-root-20",
-                          "selected": "MuiMenuItem-selected-21",
-                        }
-                      }
-                      component="div"
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
                       role="menuitem"
-                      selected={false}
+                      tabIndex={-1}
                     >
-                      <withStyles(ListItem)
-                        button={true}
-                        className="MuiMenuItem-root-20"
-                        component="div"
-                        role="menuitem"
-                        tabIndex={-1}
+                      <div
+                        key=".0"
                       >
-                        <ListItem
-                          button={true}
-                          className="MuiMenuItem-root-20"
-                          classes={
+                        <strong
+                          key="0"
+                          style={
                             Object {
-                              "button": "MuiListItem-button-30",
-                              "container": "MuiListItem-container-23",
-                              "default": "MuiListItem-default-25",
-                              "dense": "MuiListItem-dense-26",
-                              "disabled": "MuiListItem-disabled-27",
-                              "divider": "MuiListItem-divider-28",
-                              "gutters": "MuiListItem-gutters-29",
-                              "keyboardFocused": "MuiListItem-keyboardFocused-24",
-                              "root": "MuiListItem-root-22",
-                              "secondaryAction": "MuiListItem-secondaryAction-31",
+                              "fontWeight": 500,
                             }
                           }
-                          component="div"
-                          dense={false}
-                          disableGutters={false}
-                          disabled={false}
-                          divider={false}
-                          role="menuitem"
-                          tabIndex={-1}
                         >
-                          <withStyles(ButtonBase)
-                            className="MuiListItem-root-22 MuiListItem-gutters-29 MuiListItem-button-30 MuiListItem-default-25 MuiMenuItem-root-20"
-                            component="div"
-                            disabled={false}
-                            keyboardFocusedClassName="MuiListItem-keyboardFocused-24"
-                            role="menuitem"
-                            tabIndex={-1}
+                          Bellingham
+                        </strong>
+                        <span
+                          key="1"
+                          style={
+                            Object {
+                              "fontWeight": 300,
+                            }
+                          }
+                        >
+                          , WA, United States
+                        </span>
+                      </div>
+                      <withStyles(TouchRipple)
+                        center={false}
+                        innerRef={[Function]}
+                      >
+                        <TouchRipple
+                          center={false}
+                          classes={
+                            Object {
+                              "ripple": "MuiTouchRipple-ripple-69",
+                              "rippleFast": "MuiTouchRipple-rippleFast-71",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-70",
+                              "root": "MuiTouchRipple-root-65",
+                              "wrapper": "MuiTouchRipple-wrapper-66",
+                              "wrapperLeaving": "MuiTouchRipple-wrapperLeaving-67",
+                              "wrapperPulsating": "MuiTouchRipple-wrapperPulsating-68",
+                            }
+                          }
+                        >
+                          <TransitionGroup
+                            childFactory={[Function]}
+                            className="MuiTouchRipple-root-65"
+                            component="span"
+                            enter={true}
+                            exit={true}
                           >
-                            <ButtonBase
-                              centerRipple={false}
-                              className="MuiListItem-root-22 MuiListItem-gutters-29 MuiListItem-button-30 MuiListItem-default-25 MuiMenuItem-root-20"
-                              classes={
-                                Object {
-                                  "disabled": "MuiButtonBase-disabled-33",
-                                  "root": "MuiButtonBase-root-32",
-                                }
-                              }
-                              component="div"
-                              disableRipple={false}
-                              disabled={false}
-                              focusRipple={false}
-                              keyboardFocusedClassName="MuiListItem-keyboardFocused-24"
-                              role="menuitem"
-                              tabIndex={-1}
-                              type="button"
-                            >
-                              <div
-                                className="MuiButtonBase-root-32 MuiListItem-root-22 MuiListItem-gutters-29 MuiListItem-button-30 MuiListItem-default-25 MuiMenuItem-root-20"
-                                disabled={false}
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                onKeyDown={[Function]}
-                                onKeyUp={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseLeave={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                role="menuitem"
-                                tabIndex={-1}
-                              >
-                                <div
-                                  key=".0"
-                                >
-                                  <strong
-                                    key="0"
-                                    style={
-                                      Object {
-                                        "fontWeight": 500,
-                                      }
-                                    }
-                                  >
-                                    Bellingham
-                                  </strong>
-                                  <span
-                                    key="1"
-                                    style={
-                                      Object {
-                                        "fontWeight": 300,
-                                      }
-                                    }
-                                  >
-                                    , WA, United States
-                                  </span>
-                                </div>
-                                <withStyles(TouchRipple)
-                                  center={false}
-                                  innerRef={[Function]}
-                                >
-                                  <TouchRipple
-                                    center={false}
-                                    classes={
-                                      Object {
-                                        "ripple": "MuiTouchRipple-ripple-38",
-                                        "rippleFast": "MuiTouchRipple-rippleFast-40",
-                                        "rippleVisible": "MuiTouchRipple-rippleVisible-39",
-                                        "root": "MuiTouchRipple-root-34",
-                                        "wrapper": "MuiTouchRipple-wrapper-35",
-                                        "wrapperLeaving": "MuiTouchRipple-wrapperLeaving-36",
-                                        "wrapperPulsating": "MuiTouchRipple-wrapperPulsating-37",
-                                      }
-                                    }
-                                  >
-                                    <TransitionGroup
-                                      childFactory={[Function]}
-                                      className="MuiTouchRipple-root-34"
-                                      component="span"
-                                      enter={true}
-                                      exit={true}
-                                    >
-                                      <span
-                                        className="MuiTouchRipple-root-34"
-                                      />
-                                    </TransitionGroup>
-                                  </TouchRipple>
-                                </withStyles(TouchRipple)>
-                              </div>
-                            </ButtonBase>
-                          </withStyles(ButtonBase)>
-                        </ListItem>
-                      </withStyles(ListItem)>
-                    </MenuItem>
-                  </withStyles(MenuItem)>
-                </li>
-              </Item>
-            </ul>
-          </ItemsList>
-          <div
-            style={
-              Object {
-                "display": "flex",
-              }
-            }
-          >
-            <span
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <img
-              alt=""
-              src={Object {}}
-            />
-          </div>
-        </div>
-      </div>
-    </Autowhatever>
-  </Autosuggest>
-</MUIPlacesAutocomplete>
-`;
-
-exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for given application state: Initial state 1`] = `
-<MUIPlacesAutocomplete
-  classes={Object {}}
->
-  <Autosuggest
-    alwaysRenderSuggestions={false}
-    focusInputOnSuggestionClick={true}
-    getSuggestionValue={[Function]}
-    highlightFirstSuggestion={false}
-    id="1"
-    inputProps={
-      Object {
-        "autoFocus": true,
-        "classes": Object {},
-        "onChange": [Function],
-        "placeholder": "Search for a place",
-        "value": "",
-      }
-    }
-    multiSection={false}
-    onSuggestionsClearRequested={[Function]}
-    onSuggestionsFetchRequested={[Function]}
-    renderInputComponent={[Function]}
-    renderSuggestion={[Function]}
-    renderSuggestionsContainer={[Function]}
-    shouldRenderSuggestions={[Function]}
-    suggestions={Array []}
-    theme={
-      Object {
-        "container": undefined,
-        "suggestion": undefined,
-        "suggestionsContainerOpen": undefined,
-        "suggestionsList": undefined,
-      }
-    }
-  >
-    <Autowhatever
-      getSectionItems={[Function]}
-      highlightedItemIndex={null}
-      highlightedSectionIndex={null}
-      id="1"
-      inputProps={
-        Object {
-          "autoFocus": true,
-          "classes": Object {},
-          "onBlur": [Function],
-          "onChange": [Function],
-          "onFocus": [Function],
-          "onKeyDown": [Function],
-          "placeholder": "Search for a place",
-          "value": "",
-        }
-      }
-      itemProps={[Function]}
-      items={Array []}
-      multiSection={false}
-      renderInputComponent={[Function]}
-      renderItem={[Function]}
-      renderItemData={
-        Object {
-          "query": "",
-        }
-      }
-      renderItemsContainer={[Function]}
-      renderSectionTitle={[Function]}
-      theme={
-        Object {
-          "container": undefined,
-          "item": undefined,
-          "itemsContainerOpen": undefined,
-          "itemsList": undefined,
-        }
-      }
-    >
-      <div
-        key="react-autowhatever-1-container"
-        style={Object {}}
-      >
-        <TextField
-          InputProps={
+                            <span
+                              className="MuiTouchRipple-root-65"
+                            />
+                          </TransitionGroup>
+                        </TouchRipple>
+                      </withStyles(TouchRipple)>
+                    </div>
+                  </ButtonBase>
+                </withStyles(ButtonBase)>
+              </ListItem>
+            </withStyles(ListItem)>
+          </MenuItem>
+        </withStyles(MenuItem)>
+        <div
+          key=".1"
+          onFocus={[Function]}
+          style={
             Object {
-              "aria-activedescendant": null,
-              "aria-autocomplete": "list",
-              "aria-expanded": false,
-              "aria-haspopup": false,
-              "aria-owns": "react-autowhatever-1",
-              "autoComplete": "off",
-              "classes": Object {
-                "input": undefined,
-              },
-              "key": "react-autowhatever-1-input",
-              "onBlur": [Function],
-              "onChange": [Function],
-              "onFocus": [Function],
-              "onKeyDown": [Function],
-              "placeholder": "Search for a place",
-              "role": "combobox",
-              "style": Object {},
-              "type": "text",
+              "display": "flex",
             }
           }
-          autoFocus={true}
-          className={undefined}
-          inputRef={[Function]}
-          required={false}
-          select={false}
-          value=""
+          tabIndex={-1}
         >
-          <withStyles(FormControl)
-            className={undefined}
-            error={undefined}
-            fullWidth={undefined}
-            required={false}
-          >
-            <FormControl
-              className={undefined}
-              classes={
-                Object {
-                  "fullWidth": "MuiFormControl-fullWidth-4",
-                  "marginDense": "MuiFormControl-marginDense-3",
-                  "marginNormal": "MuiFormControl-marginNormal-2",
-                  "root": "MuiFormControl-root-1",
-                }
+          <span
+            style={
+              Object {
+                "flex": 1,
               }
-              component="div"
-              disabled={false}
-              error={false}
-              fullWidth={false}
-              margin="none"
-              required={false}
-            >
-              <div
-                className="MuiFormControl-root-1"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                required={false}
-              >
-                <withStyles(Input)
-                  aria-activedescendant={null}
-                  aria-autocomplete="list"
-                  aria-expanded={false}
-                  aria-haspopup={false}
-                  aria-owns="react-autowhatever-1"
-                  autoComplete="off"
-                  autoFocus={true}
-                  className={undefined}
-                  classes={
-                    Object {
-                      "input": undefined,
-                    }
-                  }
-                  defaultValue={undefined}
-                  disabled={undefined}
-                  id={undefined}
-                  inputProps={undefined}
-                  inputRef={[Function]}
-                  key="react-autowhatever-1-input"
-                  multiline={undefined}
-                  name={undefined}
-                  onBlur={[Function]}
-                  onChange={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  placeholder="Search for a place"
-                  role="combobox"
-                  rows={undefined}
-                  rowsMax={undefined}
-                  style={Object {}}
-                  type="text"
-                  value=""
-                >
-                  <Input
-                    aria-activedescendant={null}
-                    aria-autocomplete="list"
-                    aria-expanded={false}
-                    aria-haspopup={false}
-                    aria-owns="react-autowhatever-1"
-                    autoComplete="off"
-                    autoFocus={true}
-                    className={undefined}
-                    classes={
-                      Object {
-                        "disabled": "MuiInput-disabled-9",
-                        "error": "MuiInput-error-8",
-                        "focused": "MuiInput-focused-10",
-                        "formControl": "MuiInput-formControl-6",
-                        "fullWidth": "MuiInput-fullWidth-13",
-                        "inkbar": "MuiInput-inkbar-7",
-                        "input": "MuiInput-input-14",
-                        "inputDense": "MuiInput-inputDense-15",
-                        "inputDisabled": "MuiInput-inputDisabled-16",
-                        "inputMultiline": "MuiInput-inputMultiline-18",
-                        "inputSearch": "MuiInput-inputSearch-19",
-                        "inputSingleline": "MuiInput-inputSingleline-17",
-                        "multiline": "MuiInput-multiline-12",
-                        "root": "MuiInput-root-5",
-                        "underline": "MuiInput-underline-11",
-                      }
-                    }
-                    defaultValue={undefined}
-                    disableUnderline={false}
-                    disabled={undefined}
-                    fullWidth={false}
-                    id={undefined}
-                    inputProps={undefined}
-                    inputRef={[Function]}
-                    multiline={false}
-                    name={undefined}
-                    onBlur={[Function]}
-                    onChange={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    placeholder="Search for a place"
-                    role="combobox"
-                    rows={undefined}
-                    rowsMax={undefined}
-                    style={Object {}}
-                    type="text"
-                    value=""
-                  >
-                    <div
-                      aria-activedescendant={null}
-                      aria-autocomplete="list"
-                      aria-expanded={false}
-                      aria-haspopup={false}
-                      aria-owns="react-autowhatever-1"
-                      className="MuiInput-root-5 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-11"
-                      onBlur={[Function]}
-                      onFocus={[Function]}
-                      role="combobox"
-                      style={Object {}}
-                    >
-                      <input
-                        autoComplete="off"
-                        autoFocus={true}
-                        className="MuiInput-input-14 MuiInput-inputSingleline-17"
-                        defaultValue={undefined}
-                        disabled={false}
-                        id={undefined}
-                        name={undefined}
-                        onChange={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={undefined}
-                        placeholder="Search for a place"
-                        readOnly={undefined}
-                        required={undefined}
-                        rows={undefined}
-                        type="text"
-                        value=""
-                      />
-                    </div>
-                  </Input>
-                </withStyles(Input)>
-              </div>
-            </FormControl>
-          </withStyles(FormControl)>
-        </TextField>
-        <div
-          id="react-autowhatever-1"
-          key="react-autowhatever-1-items-container"
-          style={Object {}}
-        />
-      </div>
-    </Autowhatever>
-  </Autosuggest>
-</MUIPlacesAutocomplete>
+            }
+          />
+          <img
+            alt=""
+            src={Object {}}
+          />
+        </div>
+      </ul>
+    </List>
+  </withStyles(List)>
+</MenuList>
 `;
 
 exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for given application state: Suggestions rendered from 'suggestions' state 1`] = `
-<MUIPlacesAutocomplete
-  classes={Object {}}
->
-  <Autosuggest
-    alwaysRenderSuggestions={false}
-    focusInputOnSuggestionClick={true}
-    getSuggestionValue={[Function]}
-    highlightFirstSuggestion={false}
-    id="1"
-    inputProps={
-      Object {
-        "autoFocus": true,
-        "classes": Object {},
-        "onChange": [Function],
-        "placeholder": "Search for a place",
-        "value": "Bellingham",
-      }
-    }
-    multiSection={false}
-    onSuggestionsClearRequested={[Function]}
-    onSuggestionsFetchRequested={[Function]}
-    renderInputComponent={[Function]}
-    renderSuggestion={[Function]}
-    renderSuggestionsContainer={[Function]}
-    shouldRenderSuggestions={[Function]}
-    suggestions={
-      Array [
-        Object {
-          "description": "Bellingham, WA, United States",
-        },
-      ]
-    }
-    theme={
-      Object {
-        "container": undefined,
-        "suggestion": undefined,
-        "suggestionsContainerOpen": undefined,
-        "suggestionsList": undefined,
-      }
-    }
+<MenuList>
+  <withStyles(List)
+    className={undefined}
+    onBlur={[Function]}
+    onKeyDown={[Function]}
+    role="menu"
+    rootRef={[Function]}
   >
-    <Autowhatever
-      getSectionItems={[Function]}
-      highlightedItemIndex={null}
-      highlightedSectionIndex={null}
-      id="1"
-      inputProps={
+    <List
+      className={undefined}
+      classes={
         Object {
-          "autoFocus": true,
-          "classes": Object {},
-          "onBlur": [Function],
-          "onChange": [Function],
-          "onFocus": [Function],
-          "onKeyDown": [Function],
-          "placeholder": "Search for a place",
-          "value": "Bellingham",
+          "dense": "MuiList-dense-49",
+          "padding": "MuiList-padding-48",
+          "root": "MuiList-root-47",
+          "subheader": "MuiList-subheader-50",
         }
       }
-      itemProps={[Function]}
-      items={
-        Array [
-          Object {
-            "description": "Bellingham, WA, United States",
-          },
-        ]
-      }
-      multiSection={false}
-      renderInputComponent={[Function]}
-      renderItem={[Function]}
-      renderItemData={
-        Object {
-          "query": "Bellingham",
-        }
-      }
-      renderItemsContainer={[Function]}
-      renderSectionTitle={[Function]}
-      theme={
-        Object {
-          "container": undefined,
-          "item": undefined,
-          "itemsContainerOpen": undefined,
-          "itemsList": undefined,
-        }
-      }
+      component="ul"
+      dense={false}
+      disablePadding={false}
+      onBlur={[Function]}
+      onKeyDown={[Function]}
+      role="menu"
+      rootRef={[Function]}
     >
-      <div
-        key="react-autowhatever-1-container"
-        style={Object {}}
+      <ul
+        className="MuiList-root-47 MuiList-padding-48"
+        onBlur={[Function]}
+        onKeyDown={[Function]}
+        role="menu"
       >
-        <TextField
-          InputProps={
-            Object {
-              "aria-activedescendant": null,
-              "aria-autocomplete": "list",
-              "aria-expanded": true,
-              "aria-haspopup": true,
-              "aria-owns": "react-autowhatever-1",
-              "autoComplete": "off",
-              "classes": Object {
-                "input": undefined,
-              },
-              "key": "react-autowhatever-1-input",
-              "onBlur": [Function],
-              "onChange": [Function],
-              "onFocus": [Function],
-              "onKeyDown": [Function],
-              "placeholder": "Search for a place",
-              "role": "combobox",
-              "style": Object {},
-              "type": "text",
-            }
-          }
-          autoFocus={true}
-          className={undefined}
-          inputRef={[Function]}
-          required={false}
-          select={false}
-          value="Bellingham"
+        <withStyles(MenuItem)
+          component="div"
+          id="downshift-1-item-0"
+          key=".0:$Bellingham, WA, United States"
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          selected={false}
+          tabIndex={-1}
         >
-          <withStyles(FormControl)
-            className={undefined}
-            error={undefined}
-            fullWidth={undefined}
-            required={false}
-          >
-            <FormControl
-              className={undefined}
-              classes={
-                Object {
-                  "fullWidth": "MuiFormControl-fullWidth-4",
-                  "marginDense": "MuiFormControl-marginDense-3",
-                  "marginNormal": "MuiFormControl-marginNormal-2",
-                  "root": "MuiFormControl-root-1",
-                }
+          <MenuItem
+            classes={
+              Object {
+                "root": "MuiMenuItem-root-51",
+                "selected": "MuiMenuItem-selected-52",
               }
+            }
+            component="div"
+            id="downshift-1-item-0"
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            role="menuitem"
+            selected={false}
+            tabIndex={-1}
+          >
+            <withStyles(ListItem)
+              button={true}
+              className="MuiMenuItem-root-51"
               component="div"
-              disabled={false}
-              error={false}
-              fullWidth={false}
-              margin="none"
-              required={false}
+              id="downshift-1-item-0"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              role="menuitem"
+              tabIndex={-1}
             >
-              <div
-                className="MuiFormControl-root-1"
-                onBlur={[Function]}
-                onFocus={[Function]}
-                required={false}
-              >
-                <withStyles(Input)
-                  aria-activedescendant={null}
-                  aria-autocomplete="list"
-                  aria-expanded={true}
-                  aria-haspopup={true}
-                  aria-owns="react-autowhatever-1"
-                  autoComplete="off"
-                  autoFocus={true}
-                  className={undefined}
-                  classes={
-                    Object {
-                      "input": undefined,
-                    }
+              <ListItem
+                button={true}
+                className="MuiMenuItem-root-51"
+                classes={
+                  Object {
+                    "button": "MuiListItem-button-61",
+                    "container": "MuiListItem-container-54",
+                    "default": "MuiListItem-default-56",
+                    "dense": "MuiListItem-dense-57",
+                    "disabled": "MuiListItem-disabled-58",
+                    "divider": "MuiListItem-divider-59",
+                    "gutters": "MuiListItem-gutters-60",
+                    "keyboardFocused": "MuiListItem-keyboardFocused-55",
+                    "root": "MuiListItem-root-53",
+                    "secondaryAction": "MuiListItem-secondaryAction-62",
                   }
-                  defaultValue={undefined}
-                  disabled={undefined}
-                  id={undefined}
-                  inputProps={undefined}
-                  inputRef={[Function]}
-                  key="react-autowhatever-1-input"
-                  multiline={undefined}
-                  name={undefined}
-                  onBlur={[Function]}
-                  onChange={[Function]}
+                }
+                component="div"
+                dense={false}
+                disableGutters={false}
+                disabled={false}
+                divider={false}
+                id="downshift-1-item-0"
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                role="menuitem"
+                tabIndex={-1}
+              >
+                <withStyles(ButtonBase)
+                  className="MuiListItem-root-53 MuiListItem-gutters-60 MuiListItem-button-61 MuiListItem-default-56 MuiMenuItem-root-51"
+                  component="div"
+                  disabled={false}
+                  id="downshift-1-item-0"
+                  keyboardFocusedClassName="MuiListItem-keyboardFocused-55"
+                  onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  placeholder="Search for a place"
-                  role="combobox"
-                  rows={undefined}
-                  rowsMax={undefined}
-                  style={Object {}}
-                  type="text"
-                  value="Bellingham"
+                  onMouseEnter={[Function]}
+                  role="menuitem"
+                  tabIndex={-1}
                 >
-                  <Input
-                    aria-activedescendant={null}
-                    aria-autocomplete="list"
-                    aria-expanded={true}
-                    aria-haspopup={true}
-                    aria-owns="react-autowhatever-1"
-                    autoComplete="off"
-                    autoFocus={true}
-                    className={undefined}
+                  <ButtonBase
+                    centerRipple={false}
+                    className="MuiListItem-root-53 MuiListItem-gutters-60 MuiListItem-button-61 MuiListItem-default-56 MuiMenuItem-root-51"
                     classes={
                       Object {
-                        "disabled": "MuiInput-disabled-9",
-                        "error": "MuiInput-error-8",
-                        "focused": "MuiInput-focused-10",
-                        "formControl": "MuiInput-formControl-6",
-                        "fullWidth": "MuiInput-fullWidth-13",
-                        "inkbar": "MuiInput-inkbar-7",
-                        "input": "MuiInput-input-14",
-                        "inputDense": "MuiInput-inputDense-15",
-                        "inputDisabled": "MuiInput-inputDisabled-16",
-                        "inputMultiline": "MuiInput-inputMultiline-18",
-                        "inputSearch": "MuiInput-inputSearch-19",
-                        "inputSingleline": "MuiInput-inputSingleline-17",
-                        "multiline": "MuiInput-multiline-12",
-                        "root": "MuiInput-root-5",
-                        "underline": "MuiInput-underline-11",
+                        "disabled": "MuiButtonBase-disabled-64",
+                        "root": "MuiButtonBase-root-63",
                       }
                     }
-                    defaultValue={undefined}
-                    disableUnderline={false}
-                    disabled={undefined}
-                    fullWidth={false}
-                    id={undefined}
-                    inputProps={undefined}
-                    inputRef={[Function]}
-                    multiline={false}
-                    name={undefined}
-                    onBlur={[Function]}
-                    onChange={[Function]}
+                    component="div"
+                    disableRipple={false}
+                    disabled={false}
+                    focusRipple={false}
+                    id="downshift-1-item-0"
+                    keyboardFocusedClassName="MuiListItem-keyboardFocused-55"
+                    onClick={[Function]}
                     onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    placeholder="Search for a place"
-                    role="combobox"
-                    rows={undefined}
-                    rowsMax={undefined}
-                    style={Object {}}
-                    type="text"
-                    value="Bellingham"
+                    onMouseEnter={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                    type="button"
                   >
                     <div
-                      aria-activedescendant={null}
-                      aria-autocomplete="list"
-                      aria-expanded={true}
-                      aria-haspopup={true}
-                      aria-owns="react-autowhatever-1"
-                      className="MuiInput-root-5 MuiInput-focused-10 MuiInput-formControl-6 MuiInput-inkbar-7 MuiInput-underline-11"
+                      className="MuiButtonBase-root-63 MuiListItem-root-53 MuiListItem-gutters-60 MuiListItem-button-61 MuiListItem-default-56 MuiMenuItem-root-51"
+                      disabled={false}
+                      id="downshift-1-item-0"
                       onBlur={[Function]}
+                      onClick={[Function]}
                       onFocus={[Function]}
-                      role="combobox"
-                      style={Object {}}
-                    >
-                      <input
-                        autoComplete="off"
-                        autoFocus={true}
-                        className="MuiInput-input-14 MuiInput-inputSingleline-17"
-                        defaultValue={undefined}
-                        disabled={false}
-                        id={undefined}
-                        name={undefined}
-                        onChange={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={undefined}
-                        placeholder="Search for a place"
-                        readOnly={undefined}
-                        required={undefined}
-                        rows={undefined}
-                        type="text"
-                        value="Bellingham"
-                      />
-                    </div>
-                  </Input>
-                </withStyles(Input)>
-              </div>
-            </FormControl>
-          </withStyles(FormControl)>
-        </TextField>
-        <div
-          id="react-autowhatever-1"
-          key="react-autowhatever-1-items-container"
-          style={Object {}}
-        >
-          <ItemsList
-            getItemId={[Function]}
-            highlightedItemIndex={null}
-            itemProps={[Function]}
-            items={
-              Array [
-                Object {
-                  "description": "Bellingham, WA, United States",
-                },
-              ]
-            }
-            keyPrefix="react-autowhatever-1-"
-            onHighlightedItemChange={[Function]}
-            renderItem={[Function]}
-            renderItemData={
-              Object {
-                "query": "Bellingham",
-              }
-            }
-            sectionIndex={null}
-            theme={[Function]}
-          >
-            <ul
-              key="react-autowhatever-1-items-list"
-              role="listbox"
-              style={Object {}}
-            >
-              <Item
-                data-section-index={null}
-                data-suggestion-index={0}
-                id="react-autowhatever-1--item-0"
-                isHighlighted={false}
-                item={
-                  Object {
-                    "description": "Bellingham, WA, United States",
-                  }
-                }
-                itemIndex={0}
-                key="react-autowhatever-1-item-0"
-                onClick={[Function]}
-                onMouseDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                onTouchStart={[Function]}
-                renderItem={[Function]}
-                renderItemData={
-                  Object {
-                    "query": "Bellingham",
-                  }
-                }
-                sectionIndex={null}
-                style={Object {}}
-              >
-                <li
-                  data-section-index={null}
-                  data-suggestion-index={0}
-                  id="react-autowhatever-1--item-0"
-                  onClick={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                  onTouchStart={[Function]}
-                  role="option"
-                  style={Object {}}
-                >
-                  <withStyles(MenuItem)
-                    component="div"
-                    selected={false}
-                  >
-                    <MenuItem
-                      classes={
-                        Object {
-                          "root": "MuiMenuItem-root-20",
-                          "selected": "MuiMenuItem-selected-21",
-                        }
-                      }
-                      component="div"
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
                       role="menuitem"
-                      selected={false}
+                      tabIndex={-1}
                     >
-                      <withStyles(ListItem)
-                        button={true}
-                        className="MuiMenuItem-root-20"
-                        component="div"
-                        role="menuitem"
-                        tabIndex={-1}
+                      <div
+                        key=".0"
                       >
-                        <ListItem
-                          button={true}
-                          className="MuiMenuItem-root-20"
-                          classes={
+                        <strong
+                          key="0"
+                          style={
                             Object {
-                              "button": "MuiListItem-button-30",
-                              "container": "MuiListItem-container-23",
-                              "default": "MuiListItem-default-25",
-                              "dense": "MuiListItem-dense-26",
-                              "disabled": "MuiListItem-disabled-27",
-                              "divider": "MuiListItem-divider-28",
-                              "gutters": "MuiListItem-gutters-29",
-                              "keyboardFocused": "MuiListItem-keyboardFocused-24",
-                              "root": "MuiListItem-root-22",
-                              "secondaryAction": "MuiListItem-secondaryAction-31",
+                              "fontWeight": 500,
                             }
                           }
-                          component="div"
-                          dense={false}
-                          disableGutters={false}
-                          disabled={false}
-                          divider={false}
-                          role="menuitem"
-                          tabIndex={-1}
                         >
-                          <withStyles(ButtonBase)
-                            className="MuiListItem-root-22 MuiListItem-gutters-29 MuiListItem-button-30 MuiListItem-default-25 MuiMenuItem-root-20"
-                            component="div"
-                            disabled={false}
-                            keyboardFocusedClassName="MuiListItem-keyboardFocused-24"
-                            role="menuitem"
-                            tabIndex={-1}
+                          Bellingham
+                        </strong>
+                        <span
+                          key="1"
+                          style={
+                            Object {
+                              "fontWeight": 300,
+                            }
+                          }
+                        >
+                          , WA, United States
+                        </span>
+                      </div>
+                      <withStyles(TouchRipple)
+                        center={false}
+                        innerRef={[Function]}
+                      >
+                        <TouchRipple
+                          center={false}
+                          classes={
+                            Object {
+                              "ripple": "MuiTouchRipple-ripple-69",
+                              "rippleFast": "MuiTouchRipple-rippleFast-71",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-70",
+                              "root": "MuiTouchRipple-root-65",
+                              "wrapper": "MuiTouchRipple-wrapper-66",
+                              "wrapperLeaving": "MuiTouchRipple-wrapperLeaving-67",
+                              "wrapperPulsating": "MuiTouchRipple-wrapperPulsating-68",
+                            }
+                          }
+                        >
+                          <TransitionGroup
+                            childFactory={[Function]}
+                            className="MuiTouchRipple-root-65"
+                            component="span"
+                            enter={true}
+                            exit={true}
                           >
-                            <ButtonBase
-                              centerRipple={false}
-                              className="MuiListItem-root-22 MuiListItem-gutters-29 MuiListItem-button-30 MuiListItem-default-25 MuiMenuItem-root-20"
-                              classes={
-                                Object {
-                                  "disabled": "MuiButtonBase-disabled-33",
-                                  "root": "MuiButtonBase-root-32",
-                                }
-                              }
-                              component="div"
-                              disableRipple={false}
-                              disabled={false}
-                              focusRipple={false}
-                              keyboardFocusedClassName="MuiListItem-keyboardFocused-24"
-                              role="menuitem"
-                              tabIndex={-1}
-                              type="button"
-                            >
-                              <div
-                                className="MuiButtonBase-root-32 MuiListItem-root-22 MuiListItem-gutters-29 MuiListItem-button-30 MuiListItem-default-25 MuiMenuItem-root-20"
-                                disabled={false}
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                onKeyDown={[Function]}
-                                onKeyUp={[Function]}
-                                onMouseDown={[Function]}
-                                onMouseLeave={[Function]}
-                                onMouseUp={[Function]}
-                                onTouchEnd={[Function]}
-                                onTouchMove={[Function]}
-                                onTouchStart={[Function]}
-                                role="menuitem"
-                                tabIndex={-1}
-                              >
-                                <div
-                                  key=".0"
-                                >
-                                  <strong
-                                    key="0"
-                                    style={
-                                      Object {
-                                        "fontWeight": 500,
-                                      }
-                                    }
-                                  >
-                                    Bellingham
-                                  </strong>
-                                  <span
-                                    key="1"
-                                    style={
-                                      Object {
-                                        "fontWeight": 300,
-                                      }
-                                    }
-                                  >
-                                    , WA, United States
-                                  </span>
-                                </div>
-                                <withStyles(TouchRipple)
-                                  center={false}
-                                  innerRef={[Function]}
-                                >
-                                  <TouchRipple
-                                    center={false}
-                                    classes={
-                                      Object {
-                                        "ripple": "MuiTouchRipple-ripple-38",
-                                        "rippleFast": "MuiTouchRipple-rippleFast-40",
-                                        "rippleVisible": "MuiTouchRipple-rippleVisible-39",
-                                        "root": "MuiTouchRipple-root-34",
-                                        "wrapper": "MuiTouchRipple-wrapper-35",
-                                        "wrapperLeaving": "MuiTouchRipple-wrapperLeaving-36",
-                                        "wrapperPulsating": "MuiTouchRipple-wrapperPulsating-37",
-                                      }
-                                    }
-                                  >
-                                    <TransitionGroup
-                                      childFactory={[Function]}
-                                      className="MuiTouchRipple-root-34"
-                                      component="span"
-                                      enter={true}
-                                      exit={true}
-                                    >
-                                      <span
-                                        className="MuiTouchRipple-root-34"
-                                      />
-                                    </TransitionGroup>
-                                  </TouchRipple>
-                                </withStyles(TouchRipple)>
-                              </div>
-                            </ButtonBase>
-                          </withStyles(ButtonBase)>
-                        </ListItem>
-                      </withStyles(ListItem)>
-                    </MenuItem>
-                  </withStyles(MenuItem)>
-                </li>
-              </Item>
-            </ul>
-          </ItemsList>
-          <div
+                            <span
+                              className="MuiTouchRipple-root-65"
+                            />
+                          </TransitionGroup>
+                        </TouchRipple>
+                      </withStyles(TouchRipple)>
+                    </div>
+                  </ButtonBase>
+                </withStyles(ButtonBase)>
+              </ListItem>
+            </withStyles(ListItem)>
+          </MenuItem>
+        </withStyles(MenuItem)>
+        <div
+          key=".1"
+          onFocus={[Function]}
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+          tabIndex={-1}
+        >
+          <span
             style={
               Object {
-                "display": "flex",
+                "flex": 1,
               }
             }
-          >
-            <span
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
-            />
-            <img
-              alt=""
-              src={Object {}}
-            />
-          </div>
+          />
+          <img
+            alt=""
+            src={Object {}}
+          />
         </div>
-      </div>
-    </Autowhatever>
-  </Autosuggest>
-</MUIPlacesAutocomplete>
+      </ul>
+    </List>
+  </withStyles(List)>
+</MenuList>
 `;

--- a/test/test.jsx.snap
+++ b/test/test.jsx.snap
@@ -1,5 +1,247 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for given application state: Duplicate suggestions aren't rendered 1`] = `
+<MenuList>
+  <withStyles(List)
+    className={undefined}
+    onBlur={[Function]}
+    onKeyDown={[Function]}
+    role="menu"
+    rootRef={[Function]}
+  >
+    <List
+      className={undefined}
+      classes={
+        Object {
+          "dense": "MuiList-dense-49",
+          "padding": "MuiList-padding-48",
+          "root": "MuiList-root-47",
+          "subheader": "MuiList-subheader-50",
+        }
+      }
+      component="ul"
+      dense={false}
+      disablePadding={false}
+      onBlur={[Function]}
+      onKeyDown={[Function]}
+      role="menu"
+      rootRef={[Function]}
+    >
+      <ul
+        className="MuiList-root-47 MuiList-padding-48"
+        onBlur={[Function]}
+        onKeyDown={[Function]}
+        role="menu"
+      >
+        <withStyles(MenuItem)
+          component="div"
+          id="downshift-1-item-0"
+          key=".0:$Bellingham, WA, United States"
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseEnter={[Function]}
+          selected={false}
+          tabIndex={-1}
+        >
+          <MenuItem
+            classes={
+              Object {
+                "root": "MuiMenuItem-root-51",
+                "selected": "MuiMenuItem-selected-52",
+              }
+            }
+            component="div"
+            id="downshift-1-item-0"
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseEnter={[Function]}
+            role="menuitem"
+            selected={false}
+            tabIndex={-1}
+          >
+            <withStyles(ListItem)
+              button={true}
+              className="MuiMenuItem-root-51"
+              component="div"
+              id="downshift-1-item-0"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseEnter={[Function]}
+              role="menuitem"
+              tabIndex={-1}
+            >
+              <ListItem
+                button={true}
+                className="MuiMenuItem-root-51"
+                classes={
+                  Object {
+                    "button": "MuiListItem-button-61",
+                    "container": "MuiListItem-container-54",
+                    "default": "MuiListItem-default-56",
+                    "dense": "MuiListItem-dense-57",
+                    "disabled": "MuiListItem-disabled-58",
+                    "divider": "MuiListItem-divider-59",
+                    "gutters": "MuiListItem-gutters-60",
+                    "keyboardFocused": "MuiListItem-keyboardFocused-55",
+                    "root": "MuiListItem-root-53",
+                    "secondaryAction": "MuiListItem-secondaryAction-62",
+                  }
+                }
+                component="div"
+                dense={false}
+                disableGutters={false}
+                disabled={false}
+                divider={false}
+                id="downshift-1-item-0"
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseEnter={[Function]}
+                role="menuitem"
+                tabIndex={-1}
+              >
+                <withStyles(ButtonBase)
+                  className="MuiListItem-root-53 MuiListItem-gutters-60 MuiListItem-button-61 MuiListItem-default-56 MuiMenuItem-root-51"
+                  component="div"
+                  disabled={false}
+                  id="downshift-1-item-0"
+                  keyboardFocusedClassName="MuiListItem-keyboardFocused-55"
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseEnter={[Function]}
+                  role="menuitem"
+                  tabIndex={-1}
+                >
+                  <ButtonBase
+                    centerRipple={false}
+                    className="MuiListItem-root-53 MuiListItem-gutters-60 MuiListItem-button-61 MuiListItem-default-56 MuiMenuItem-root-51"
+                    classes={
+                      Object {
+                        "disabled": "MuiButtonBase-disabled-64",
+                        "root": "MuiButtonBase-root-63",
+                      }
+                    }
+                    component="div"
+                    disableRipple={false}
+                    disabled={false}
+                    focusRipple={false}
+                    id="downshift-1-item-0"
+                    keyboardFocusedClassName="MuiListItem-keyboardFocused-55"
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    onMouseEnter={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                    type="button"
+                  >
+                    <div
+                      className="MuiButtonBase-root-63 MuiListItem-root-53 MuiListItem-gutters-60 MuiListItem-button-61 MuiListItem-default-56 MuiMenuItem-root-51"
+                      disabled={false}
+                      id="downshift-1-item-0"
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      role="menuitem"
+                      tabIndex={-1}
+                    >
+                      <div
+                        key=".0"
+                      >
+                        <strong
+                          key="0"
+                          style={
+                            Object {
+                              "fontWeight": 500,
+                            }
+                          }
+                        >
+                          Bellingham
+                        </strong>
+                        <span
+                          key="1"
+                          style={
+                            Object {
+                              "fontWeight": 300,
+                            }
+                          }
+                        >
+                          , WA, United States
+                        </span>
+                      </div>
+                      <withStyles(TouchRipple)
+                        center={false}
+                        innerRef={[Function]}
+                      >
+                        <TouchRipple
+                          center={false}
+                          classes={
+                            Object {
+                              "ripple": "MuiTouchRipple-ripple-69",
+                              "rippleFast": "MuiTouchRipple-rippleFast-71",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible-70",
+                              "root": "MuiTouchRipple-root-65",
+                              "wrapper": "MuiTouchRipple-wrapper-66",
+                              "wrapperLeaving": "MuiTouchRipple-wrapperLeaving-67",
+                              "wrapperPulsating": "MuiTouchRipple-wrapperPulsating-68",
+                            }
+                          }
+                        >
+                          <TransitionGroup
+                            childFactory={[Function]}
+                            className="MuiTouchRipple-root-65"
+                            component="span"
+                            enter={true}
+                            exit={true}
+                          >
+                            <span
+                              className="MuiTouchRipple-root-65"
+                            />
+                          </TransitionGroup>
+                        </TouchRipple>
+                      </withStyles(TouchRipple)>
+                    </div>
+                  </ButtonBase>
+                </withStyles(ButtonBase)>
+              </ListItem>
+            </withStyles(ListItem)>
+          </MenuItem>
+        </withStyles(MenuItem)>
+        <div
+          key=".1"
+          onFocus={[Function]}
+          style={
+            Object {
+              "display": "flex",
+            }
+          }
+          tabIndex={-1}
+        >
+          <span
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          />
+          <img
+            alt=""
+            src={Object {}}
+          />
+        </div>
+      </ul>
+    </List>
+  </withStyles(List)>
+</MenuList>
+`;
+
 exports[`React component test: <MUIPlacesAutocomplete> Renders correctly for given application state: Google logo is present in a populated list of suggestions 1`] = `
 <MenuList>
   <withStyles(List)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,6 +1952,10 @@ dotenv@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
 
+downshift@^1.22.5:
+  version "1.22.5"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.22.5.tgz#48103b2f80259157b01b96d6bdc344c51ce0743e"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -2013,20 +2017,20 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-adapter-react-16@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.0.2.tgz#8c6f431f17c69e1e9eeb25ca4bd92f31971eb2dd"
+enzyme-adapter-react-16@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.0.tgz#86c5db7c10f0be6ec25d54ca41b59f2abb397cf4"
   dependencies:
-    enzyme-adapter-utils "^1.0.0"
+    enzyme-adapter-utils "^1.1.0"
     lodash "^4.17.4"
     object.assign "^4.0.4"
     object.values "^1.0.4"
     prop-types "^15.5.10"
     react-test-renderer "^16.0.0-0"
 
-enzyme-adapter-utils@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.0.1.tgz#fcd81223339a55a312f7552641e045c404084009"
+enzyme-adapter-utils@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.2.0.tgz#7f4471ee0a70b91169ec8860d2bf0a6b551664b2"
   dependencies:
     lodash "^4.17.4"
     object.assign "^4.0.4"
@@ -4393,10 +4397,6 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
-
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -4906,7 +4906,7 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
-raf@^3.3.2:
+raf@^3.3.2, raf@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
   dependencies:
@@ -4964,22 +4964,6 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-autosuggest@^9.3.2:
-  version "9.3.2"
-  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.3.2.tgz#dd8c0fbe9c25aa94afe296180353647f6ecc10a7"
-  dependencies:
-    prop-types "^15.5.10"
-    react-autowhatever "^10.1.0"
-    shallow-equal "^1.0.0"
-
-react-autowhatever@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/react-autowhatever/-/react-autowhatever-10.1.0.tgz#41f6d69382437d3447a0a3c8913bb8ca2feaabc1"
-  dependencies:
-    prop-types "^15.5.8"
-    react-themeable "^1.1.0"
-    section-iterator "^2.0.0"
-
 react-dom@^16.0.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
@@ -5033,12 +5017,6 @@ react-test-renderer@^16.0.0-0:
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
-
-react-themeable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
-  dependencies:
-    object-assign "^3.0.0"
 
 react-transition-group@^2.2.1:
   version "2.2.1"
@@ -5400,10 +5378,6 @@ scroll@^2.0.1:
   dependencies:
     rafl "~1.2.1"
 
-section-iterator@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
-
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -5511,10 +5485,6 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
-
-shallow-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.0.0.tgz#508d1838b3de590ab8757b011b25e430900945f7"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This PR provides fixes for bugs:
* #13 - Suggestions container has height set
* #14 - Suggestions container doesn't render over (popover) components/elements

The primary fix we are concerned with is #14. In providing a fix for #14 I dropped the use of `react-autosuggest` for `downshift` to provide dropdown/autosuggest functionality. I found it much easier to work with when trying to popover the suggestions container over some components/elements. By no means is this an endorsement that `react-autosuggest` isn't a suitable package/component to meet other peoples/projects needs. I'm sure I could have gotten things to work with it had I sunk lots more time into it (on top of a ton of time I already had) and/or wasn't so inexperienced. Anyways...

When reviewing please pay close attention to the changes made to `src/MUIPlacesAutocomplete.jsx' as that is where I need the most feedback/votes of confidence.

@oliviertassinari
If you have time I would love for you to look things over so I can learn from your feedback/insights. I know you are busy and won't hold up the merge if you can provide feedback right now (or just don't desire to) but if you do get time to provide feedback in the future I can make changes retroactively.