### PR TITLE
Fix: Trigger publish from merge #15 fixing bugs #13 & #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This component also has testing which makes use of the Places library in the Goo
 ### Props
 
 | Prop | Type | Required | Description |
-| :--- | :--- | :---: | :--- |
+| :--- | :--- | :------: | :---------- |
 | `renderTarget` | Function | ✓ | Renders the components/elements that you would like to have the list of suggestions popover. |
 
 # Feedback


### PR DESCRIPTION
Merge #15 made fixes to bugs #13 and #14 which would be reason for us to rev our version according to semver rules. `semantic-release` should take care of the version rev as well as publish a new package for us automatically. Unfortunately it didn't because the title of the MR didn't match ESLint commit message rules.

The title was "Fix (#13, #14): Render suggestions over (popover) components/elements" and due to non-alphanumeric characters being in the token "Fix (#13, #14):", `semantic-release` didn't consider the merge as making changes that would result in a version rev.

This MR is simply to trigger the publishing of a new version. This is silly but needs to be done. An alternative was to amend the commit message of merge #15 but this isn't recommended as it changes the history and those that cloned would have to manually update their local history.

I think moving forward we need to do the following:
* Move to Angular commit messages semantics as it seems to be the standard that is being adopted
* Lint our commit messages
* Ensure that the MR titles adhere to Angular commit message semantics (can we lint/gate that?)

After this is merged and our package version is updated and automatically published we may need to revisit/edit the changelog notes attached to the new tagged version to ensure we capture information from merge #15.