### PR TITLE
New: Fire callback when suggestion selected (fixes #17)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,10 @@
       2,
       "never"
     ],
+    "function-paren-newline": [
+      "error",
+      "consistent"
+    ],
     "object-curly-newline": [
       "error",
       {

--- a/README.md
+++ b/README.md
@@ -41,11 +41,32 @@ npm run demo
 # Usage
 ```javascript
 import React from 'react'
-import SomeCoolComponent from 'some-third-party-package'
+import SomeCoolComponent from 'some-cool-component'
 import MUIPlacesAutocomplete from 'mui-places-autocomplete'
 
-// Use 'renderTarget' prop to render a component/target we want the suggestions to popover
-const Example = () => (<MUIPlacesAutocomplete renderTarget={() => (<SomeCoolComponent />)} />)
+class Example extends React.Component {
+  constructor() {
+    super()
+
+    this.onSuggestionSelected = this.onSuggestionSelected.bind(this)
+  }
+
+  onSuggestionSelected(suggestion) {
+    // Add your business logic here. In this case we just log...
+    console.log('Selected suggestion:', suggestion)
+  }
+
+  render() {
+    // Use 'renderTarget' prop to render a component/target we want the suggestions to popover
+
+    return (
+      <MUIPlacesAutocomplete
+        onSuggestionSelected={this.onSuggestionSelected}
+        renderTarget={() => (<SomeCoolComponent />)}
+      /> 
+    )
+  }
+}
 
 export default Example
 ```
@@ -73,7 +94,22 @@ This component also has testing which makes use of the Places library in the Goo
 
 | Prop | Type | Required | Description |
 | :--- | :--- | :---: | :--- |
-| `renderTarget` | Function | ✓ | Renders the components/elements that you would like to have the list of suggestions popover. |
+| [`onSuggestionSelected`](#onSuggestionSelected) | Function | ✓ | Callback that provides the selected suggestion. |
+| [`renderTarget`](#renderTarget) | Function | ✓ | Renders the components/elements that you would like to have the list of suggestions popover. |
+
+<a name="onSuggestionSelected"></a>
+#### onSuggestionSelected (required)
+
+This function will be called everytime a user has selected a suggestion. It has the following signature:
+
+```javascript
+function onSuggestionSelected(suggestion)
+```
+
+<a name="renderTarget"></a>
+#### renderTarget (required)
+
+This function is invoked during rendering. It ought to return the components/elements that you want the list of suggestions to render (pop) over.
 
 # Feedback
 This was my first open-source project that I undertook while I was teaching myself full-stack development (JS (ES6)/HTML/CSS, Node, Express, NoSQL (DynamoDB), GraphQL, React, Redux, Material-UI, etc.). I'm very interested in taking feedback to either improve my skills (i.e. correct errors :)) or to make this component more useful in general/for your use case. Please feel free to provide feedback by opening an issue or messaging me.

--- a/demo/Demo.jsx
+++ b/demo/Demo.jsx
@@ -1,6 +1,45 @@
 import React from 'react'
+import Snackbar from 'material-ui/Snackbar'
 import MUIPlacesAutocomplete from './../dist'
 
-const Demo = () => (<MUIPlacesAutocomplete renderTarget={() => (<div />)} />)
+class Demo extends React.Component {
+  constructor() {
+    super()
+
+    this.state = { open: false, suggestion: null }
+
+    this.onClose = this.onClose.bind(this)
+    this.onSuggestionSelected = this.onSuggestionSelected.bind(this)
+  }
+
+  onClose() {
+    this.setState({ open: false, suggestion: null })
+  }
+
+  onSuggestionSelected(suggestion) {
+    // Add your business logic here. In this case we simply set our state to show our <Snackbar>.
+    this.setState({ open: true, suggestion })
+  }
+
+  render() {
+    const { open, suggestion } = this.state
+
+    return (
+      <div>
+        <MUIPlacesAutocomplete
+          onSuggestionSelected={this.onSuggestionSelected}
+          renderTarget={() => (<div />)}
+        />
+        <Snackbar
+          onRequestClose={this.onClose}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+          autoHideDuration={5000}
+          open={open}
+          message={suggestion ? (<span>Selected suggestion: {suggestion.description}</span>) : ''}
+        />
+      </div>
+    )
+  }
+}
 
 export default Demo

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "yarn test:mocha && yarn test:eslint",
     "test:mocha": "mocha --exit --require babel-register --require ignore-styles --require test/setup-dom.js test/test.jsx",
     "test:eslint": "eslint --max-warnings 0 --cache --ext .js,.jsx src test demo",
-    "demo": "webpack-dev-server --config demo/webpack.config.js --content-base dist --hot",
+    "demo": "webpack-dev-server --config demo/webpack.config.js --content-base dist --hot --host 0.0.0.0",
     "build": "rm -rf dist/ && webpack",
     "prepublish": "yarn build && yarn test",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"


### PR DESCRIPTION
This PR is to implement functionality as documented in #17. We are providing a callback for when a suggestion is clicked on by the user. It ought to have been implemented before we released but it slipped my mind. Everyone that has been downloading/cloning `<MUIPlacesAutocomplete>` have had a useless component unless they modified it themselves. But now it ought to be useful enough for use.