### PR TITLE
Fix: Guard against 'null' description when losing focus (fixes #19)

### DIFF
--- a/src/MUIPlacesAutocomplete.jsx
+++ b/src/MUIPlacesAutocomplete.jsx
@@ -258,7 +258,7 @@ export default class MUIPlacesAutocomplete extends React.Component {
       <Downshift
         onSelect={this.onSuggestionSelected}
         onInputValueChange={this.onInputValueChange}
-        itemToString={({ description }) => description}
+        itemToString={suggestion => (suggestion ? suggestion.description : '')}
         render={this.renderAutocomplete}
       />
     )


### PR DESCRIPTION
There is an issue where if you search and render suggestions for the first time (i.e. a suggestion hasn't been selected yet) and click away so that focus is lost then you will receive an error of the form: "Uncaught TypeError: Cannot read property 'description' of null".

This error occurs in the function we pass to the 'itemToString' prop when rendering the <Downshift> component. Its a result of no suggestions being available yet trying to destructure the 'description' property off of a suggestion.

This commit provides a fix to guard against the case where there are no suggestions, in which case we simply return the empty string.

This PR fixes bug: #19