### PR TITLE
New: Add geocoding utility functions (fixes #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 * Easy-to-use component for searching for places
 * Place suggestions displayed in realtime
 * Input state can be controlled externally
+* Promise based [geocoding utility functions (latitude/longitude)](#geocodingFunctions)
 * Google Material Design styling provided by next version of Material-UI (v1)
 * Safe to render on the server (SSR)
 * Integrates with other 3rd party libraries (e.g. [Redux Form](#advancedUsage))
@@ -25,7 +26,7 @@ or
 npm install mui-places-autocomplete --save --ignore-scripts
 ```
 
-Note that if you exclude the `--ignore-scripts` option when installing a package then the `prepublish` script in `package.json` is ran after installing locally. Tests are ran as part of the `prepublish` script and they will fail if you haven't yet set a Google API key to the enivronment variable `GOOGLE_API_KEY` (see [setup section](#setup)).
+Note that if you exclude the `--ignore-scripts` option when installing a package then the `prepublish` script in `package.json` is ran after installing locally. Tests are ran as part of the `prepublish` script and they will fail if you haven't yet set a Google API key to the enivronment variables `GOOGLE_API_KEY` or `GOOGLE_API_TEST_KEY` (see [setup section](#setup)).
 
 # Demo
 **Note that you must have followed the [setup steps](#setup) to run the demo as it depends on services provided by Google.**
@@ -79,13 +80,15 @@ export default Example
 ### Advanced Usage
 
 * [DemoControlledInput.jsx](https://github.com/Giners/mui-places-autocomplete/blob/master/demo/DemoControlledInput.jsx) - Example that shows how to control the `<input>` element as well as integrate with Redux Form.
+* [DemoGeocodeLatLong.jsx](https://github.com/Giners/mui-places-autocomplete/blob/master/demo/DemoGeocodeLatLong.jsx) - Example that shows how to obtain the latitude/longitude of a selected suggestion.
 
 <a name="setup"></a>
 ### Setup
 This component relies on some basic setup before usage. It makes use of services provided by Google. To properly make use of the services you will need to do three things:
 1. Enable the Google Places API Web Service
-2. Enable the Google Maps JavaScript API
-3. Obtain a Google API key
+2. (Optional) Enable the Google Maps Geocoding API (only required if making use of the [geocoding utility functions](#geocodingFunctions))
+3. Enable the Google Maps JavaScript API
+4. Obtain a Google API key
 
 You can do all of these things from your Google developers console here: https://console.developers.google.com
 
@@ -97,7 +100,7 @@ The component relies on the Places library in the Google Maps JavaScript API. To
 
 Be sure that you replace `YOUR_API_KEY` with the one you just created or obtained previously.
 
-This component also has testing which makes use of the Places library in the Google Maps JavaScript API. Rather than loading the Places library it uses a module provided by Google. It also requires an API key. This key can be provided to a file @ `test/api-key.js`. If you would like it can also be provided as an environment variable named `GOOGLE_API_KEY`.
+This component also has testing which makes use of the Places library in the Google Maps JavaScript API. Rather than loading the Places library it uses a module provided by Google. It also requires an API key. This key can be provided to a file @ `test/api-key.js`. If you would like it can also be provided as an environment variable named `GOOGLE_API_KEY` or `GOOGLE_API_TEST_KEY`.
 
 ### Props
 
@@ -180,12 +183,96 @@ const { inputValue } = getState()
 
 If you would like to have consistency between the controlled `<input>` elements state as well as any suggestions that are selected then you need to update the controlled state of the `<input>` element when a [suggestion is selected](#onSuggestionSelected). There is an example of how to do this in the [advanced usage section](#advancedUsage).
 
+<a name="geocodingFunctions"></a>
+### Geocoding utility functions (latitude/longitude)
+
+`<MUIPlacesAutocomplete>` is focused on providing functionality for searching for places of interest and providing realtime suggestions to searches. To accomplish this `<MUIPlacesAutocomplete>` leverages the Google Places API Web Service to provide place suggestions. The place suggestions returned by the Google Places API Web Service doesn't include any geospatial data (i.e. latitude/longitude). Depending on your use case you may require geospatial data about the suggestions.
+
+To facilitate consumers of `<MUIPlacesAutocomplete>` and their different use cases, geocoding utility functions have been packaged together with the `<MUIPlacesAutocomplete>` component. Geocoding will allow you to convert addresses into geospatial data/coordinates such as latitude and longitude. For a complete demo showing how to use the geocoding utility functions see the [advanced usage section](#advancedUsage).
+
+**Note:** To make use of the geocoding utility functions you must enable the Google Maps Geocoding API. For more info see the [setup section](#setup).
+
+<a name="geocodeByPlaceID"></a>
+#### geocodeByPlaceID
+
+Each suggestion returned to `<MUIPlacesAutocomplete>` by the Google Places API Web Service has a property named `place_id`. The `place_id` property contains a value that uniquely identifies a place in the Google Places database. The `place_id` property can be used in conjunction with the `geocodeByPlaceID()` function to get geospatial data for any suggestion.
+
+The `geocodeByPlaceID()` function has the following signature:
+
+```javascript
+function geocodeByPlaceID(placeId)
+```
+
+Where:
+* `placeId` - Unique identifier for a place in the Google Places database
+
+The `geocodeByPlaceID()` function returns a promise that contains the results of the request made with the Google Maps Geocoding API.
+
+```javascript
+import React from 'react'
+import SomeCoolComponent from 'some-cool-component'
+import MUIPlacesAutocomplete, { geocodeByPlaceID } from 'mui-places-autocomplete'
+
+class Example extends React.Component {
+  constructor() {
+    super()
+
+    // Setup your state here...
+    this.state = { coordinates: null }
+
+    this.onSuggestionSelected = this.onSuggestionSelected.bind(this)
+  }
+
+  onSuggestionSelected(suggestion) {
+    geocodeByPlaceID(suggestion.place_id).then((results) => {
+      // Add your business logic here. In this case we simply set our state with the coordinates of
+      // the selected suggestion...
+
+      // Just use the first result in the list to get the geometry coordinates
+      const { geometry } = results[0]
+
+      const coordinates = {
+        lat: geometry.location.lat(),
+        lng: geometry.location.lng(),
+      }
+
+      this.setState({ coordinates })
+    }).catch((err) => {
+      // Handle any errors that occurred when we tried to get geospatial data for a selected
+      // suggestion...
+    })
+  }
+
+  render() {
+    // Your render logic here...
+  }
+}
+
+export default Example
+```
+
+The properties that are returned on the array of geocode results are documented here: [GeocodeResult API object specification](https://developers.google.com/maps/documentation/javascript/reference/3/#GeocoderResult)
+
+#### geocodeBySuggestion
+
+The `geocodeBySuggestion()` function is a wrapper around the [`geocodeByPlaceID()`](#geocodeByPlaceID) function. It has the following signature:
+
+```javascript
+function geocodeBySuggestion(suggestion)
+```
+
+Where:
+* `suggestion` - Object representing a suggestion returned by the Google Places API Web Service which has a property named `place_id` that uniquely identifies a place in the Google Places database.
+
+It has the same behavior as the `geocodeByPlaceID()` function where it returns a promise that contains the results of the request made with the Google Maps Geocoding API.
+
 # Feedback
 This was my first open-source project that I undertook while I was teaching myself full-stack development (JS (ES6)/HTML/CSS, Node, Express, NoSQL (DynamoDB), GraphQL, React, Redux, Material-UI, etc.). I'm very interested in taking feedback to either improve my skills (i.e. correct errors :)) or to make this component more useful in general/for your use case. Please feel free to provide feedback by opening an issue or messaging me.
 
 # References
 * Info about the Google Maps JavaScript API: https://developers.google.com/maps/documentation/javascript/libraries
-* Overview and examples for the Autocomplete features in the Places library: https://developers.google.com/maps/documentation/javascript/places-autocomplete
+* Overview and examples for the Autocomplete features in the Maps library: https://developers.google.com/maps/documentation/javascript/places-autocomplete
+* Overview and examples for the Geocoding features in the Maps library: https://developers.google.com/maps/documentation/geocoding/intro
 
 # License
 [MIT](https://gine.mit-license.org/)

--- a/demo/Demo.jsx
+++ b/demo/Demo.jsx
@@ -17,6 +17,7 @@ import Typography from 'material-ui/Typography'
 import rootReducer from './rootReducer'
 import DemoBasic from './DemoBasic'
 import DemoControlledInput from './DemoControlledInput'
+import DemoGeocodeLatLong from './DemoGeocodeLatLong'
 
 // Map of demos that one can select to view
 const demos = {
@@ -24,6 +25,10 @@ const demos = {
   [DemoControlledInput.name]: {
     description: DemoControlledInput.description,
     component: DemoControlledInput,
+  },
+  [DemoGeocodeLatLong.name]: {
+    description: DemoGeocodeLatLong.description,
+    component: DemoGeocodeLatLong,
   },
 }
 

--- a/demo/DemoGeocodeLatLong.jsx
+++ b/demo/DemoGeocodeLatLong.jsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import Snackbar from 'material-ui/Snackbar'
+import MUIPlacesAutocomplete, { geocodeBySuggestion } from './../dist'
+
+class DemoGeocodeLatLong extends React.Component {
+  constructor() {
+    super()
+
+    this.state = { open: false, coordinates: null, errorMessage: null }
+
+    this.onClose = this.onClose.bind(this)
+    this.onSuggestionSelected = this.onSuggestionSelected.bind(this)
+  }
+
+  onClose() {
+    // Be sure to reset our coordinates/errorMessage so we can render the message displayed in the
+    // <Snackbar> appropriately (see 'renderMessage()').
+    this.setState({ open: false, coordinates: null, errorMessage: null })
+  }
+
+  onSuggestionSelected(suggestion) {
+    // Once a suggestion has been selected by your consumer you can use the utility geocoding
+    // functions to get the latitude and longitude for the selected suggestion.
+    geocodeBySuggestion(suggestion).then((results) => {
+      if (results.length < 1) {
+        this.setState({
+          open: true,
+          errorMessage: 'Geocode request completed successfully but without any results',
+        })
+
+        return
+      }
+
+      // Just use the first result in the list to get the geometry coordinates
+      const { geometry } = results[0]
+
+      const coordinates = {
+        lat: geometry.location.lat(),
+        lng: geometry.location.lng(),
+      }
+
+      // Add your business logic here. In this case we simply set our state to show our <Snackbar>.
+      this.setState({ open: true, coordinates })
+    }).catch((err) => {
+      this.setState({ open: true, errorMessage: err.message })
+    })
+  }
+
+  renderMessage() {
+    const { coordinates, errorMessage } = this.state
+
+    if (coordinates) {
+      return `Selected suggestions geocoded latitude is ${coordinates.lat} and longitude is ${coordinates.lng}`
+    } else if (errorMessage) {
+      return `Failed to geocode suggestion because: ${errorMessage}`
+    }
+
+    // If we don't have any coordinates or error message to render (probably due to being rendered
+    // the first time) then render nothing
+    return null
+  }
+
+  render() {
+    const { open } = this.state
+
+    return (
+      <div>
+        <MUIPlacesAutocomplete
+          onSuggestionSelected={this.onSuggestionSelected}
+          renderTarget={() => (<div />)}
+        />
+        <Snackbar
+          onClose={this.onClose}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+          autoHideDuration={5000}
+          open={open}
+          message={(<span>{this.renderMessage()}</span>)}
+          style={{ width: '70vw' }}
+        />
+      </div>
+    )
+  }
+}
+
+DemoGeocodeLatLong.description = 'Geocoding (i.e. latitude/longitude) a selected suggestion'
+
+export default DemoGeocodeLatLong

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "yarn test:mocha && yarn test:eslint",
-    "test:mocha": "mocha --exit --require babel-register --require ignore-styles --require test/setup-dom.js test/test.jsx",
+    "test:mocha": "mocha --exit --require babel-register --require ignore-styles --require test/setup-dom.js test/test.jsx test/testGeocode.js",
     "test:eslint": "eslint --max-warnings 0 --cache --ext .js,.jsx src test demo",
     "demo": "webpack-dev-server --config demo/webpack.config.js --content-base dist --hot --host 0.0.0.0",
     "build": "rm -rf dist/ && webpack",

--- a/src/geocode.js
+++ b/src/geocode.js
@@ -1,0 +1,28 @@
+export const geocodeByPlaceID = (placeId) => {
+  // After the component is mounted it is safe to create a new instance of the Geocoder client.
+  // That's because at this point the Google Maps JavaScript API has been loaded. Also if we do it
+  // before the component is mounted (i.e. in 'componentWillMount()') we won't be safe to render
+  // on the server (SSR) as the 'window' object isn't available.
+  const geocoder = new window.google.maps.Geocoder()
+
+  return new Promise((resolve, reject) => {
+    geocoder.geocode({ placeId }, (results, status) => {
+      if (status !== window.google.maps.GeocoderStatus.OK) {
+        reject(
+          new Error(
+            `Geocoding query for a place with an ID of '${placeId}' failed - response status: ${status}`,
+          ),
+        )
+
+        return
+      }
+
+      resolve(results)
+    })
+  })
+}
+
+// Disable the ESLint rule camelcase on the next line as the suggestions returned from the Google
+// Maps service have properties that are snake cased
+// eslint-disable-next-line camelcase
+export const geocodeBySuggestion = ({ place_id }) => geocodeByPlaceID(place_id)

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 import MUIPlacesAutocomplete from './MUIPlacesAutocomplete'
+import { geocodeByPlaceID, geocodeBySuggestion } from './geocode'
 
+export { geocodeByPlaceID, geocodeBySuggestion }
 export default MUIPlacesAutocomplete

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -16,7 +16,7 @@ import React from 'react'
 import MUIPlacesAutocomplete from './../src'
 
 // Supporting test code
-import getACServiceClassDef from './testHelper'
+import { getACServiceClassDef } from './testHelper'
 
 // Configure Chai to work with Jest
 chai.use(chaiJestSnapshot)

--- a/test/testGeocode.js
+++ b/test/testGeocode.js
@@ -1,0 +1,138 @@
+// Disable 'prefer-arrow-callback' as Mocha recommends against passing arrow functions to Mocha. See
+// https://mochajs.org/#arrow-functions for more info.
+// Disable 'func-names' so we can use anonymous functions as a convenience to us as test writers.
+/* eslint prefer-arrow-callback: 0, func-names: 0 */
+/* eslint no-unused-expressions: 0, chai-friendly/no-unused-expressions: 2 */
+
+// 3rd-party supporting test libs
+import { expect } from 'chai'
+
+// Code under test
+import { geocodeByPlaceID, geocodeBySuggestion } from './../src'
+
+// Supporting test code
+import { getGeocoderServiceClassDef } from './testHelper'
+
+describe('Geocoding utilities:', function () {
+  before('"Load" the Google Maps JavaScript API on \'window\'', function () {
+    // These tests depend on a DOM to be setup. At this point we presume that the DOM has been setup
+    // and we can add additional properties to the global 'window' object.
+    expect(global.window).to.exist
+
+    // The geocoding utility functions expect the Google Maps JavaScript API to be loaded in the
+    // 'window' object. We "load" the API onto the 'window' object my mocking it out and making
+    // available the API from the Google Maps JavaScript library that is a dev dependency to this
+    // project.
+    global.window.google = {
+      maps: {
+        Geocoder: getGeocoderServiceClassDef(),
+        // Don't forget to mock out the status' that are used by the geocoding utility functions
+        GeocoderStatus: {
+          OK: 'OK',
+        },
+      },
+    }
+  })
+
+  describe('geocodeByPlaceID():', function () {
+    it('Promise is resolved with geocoding geocodeResults', function (done) {
+      const spaceNeedlePlaceID = 'ChIJ2cTu4UUVkFQRM-XCxwhyzEQ'
+
+      const promise = geocodeByPlaceID(spaceNeedlePlaceID)
+
+      promise.then((geocodeResults) => {
+        expect(geocodeResults).to.be.an('array')
+        expect(geocodeResults).to.have.lengthOf(1)
+
+        const result = geocodeResults[0]
+
+        expect(result).to.be.an('object')
+        expect(result.place_id).to.equal(spaceNeedlePlaceID)
+        expect(result.geometry).to.be.an('object')
+
+        const { location } = result.geometry
+
+        expect(location).to.be.an('object')
+
+        // Note that the 'geocodeResults' passed to us are from using the actual Google Maps
+        // JavaScript API as a module for development purposes and not the one downloaded from
+        // embedding it as a <script> in your site. The 'lat' and 'lng' properties are actual
+        // primitive Numbers from using the Google Maps JavaScript API as a module whereas if we
+        // downloaded the API then they would be functions.
+        expect(location.lat).to.exist
+        expect(location.lng).to.exist
+
+        done()
+      }).catch((err) => {
+        done(err)
+      })
+    })
+
+    it('Promise is rejected on an error', function (done) {
+      // Use an invalid place ID to generate an error. This ought to generate an 'INVALID_REQUEST'
+      // for the error response.
+      const placeID = 'lol not a real placeID'
+
+      const promise = geocodeByPlaceID(placeID)
+
+      promise.then(() => {
+        done(new Error('Promise was resolved when it should have been rejected'))
+      }).catch(() => {
+        done()
+      })
+    })
+  })
+
+  describe('geocodeBySuggestion():', function () {
+    it('Promise is resolved with geocoding geocodeResults', function (done) {
+      const spaceNeedleSuggestion = {
+        place_id: 'ChIJ2cTu4UUVkFQRM-XCxwhyzEQ',
+      }
+
+      const promise = geocodeBySuggestion(spaceNeedleSuggestion)
+
+      promise.then((geocodeResults) => {
+        expect(geocodeResults).to.be.an('array')
+        expect(geocodeResults).to.have.lengthOf(1)
+
+        const result = geocodeResults[0]
+
+        expect(result).to.be.an('object')
+        expect(result.place_id).to.equal(spaceNeedleSuggestion.place_id)
+        expect(result.geometry).to.be.an('object')
+
+        const { location } = result.geometry
+
+        expect(location).to.be.an('object')
+
+        // Note that the 'geocodeResults' passed to us are from using the actual Google Maps
+        // JavaScript API as a module for development purposes and not the one downloaded from
+        // embedding it as a <script> in your site. The 'lat' and 'lng' properties are actual
+        // primitive Numbers from using the Google Maps JavaScript API as a module whereas if we
+        // downloaded the API then they would be functions.
+        expect(location.lat).to.exist
+        expect(location.lng).to.exist
+
+        done()
+      }).catch((err) => {
+        done(err)
+      })
+    })
+
+    it('Promise is rejected on an error', function (done) {
+      // Use an invalid place ID to generate an error. This ought to generate an 'INVALID_REQUEST'
+      // for the error response.
+      const spaceNeedleSuggestion = {
+        place_id: 'lol not a real placeID',
+      }
+
+      const promise = geocodeBySuggestion(spaceNeedleSuggestion)
+
+      promise.then(() => {
+        done(new Error('Promise was resolved when it should have been rejected'))
+      }).catch(() => {
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR is for adding utility functions to perform geocoding requests using the Google Maps JavaScript API. Those that are interested in it can use the geocoding utility functions named 'geocodeByPlaceID' and
'geocodeBySuggestion' to get the latitude and longitude of a suggestion.