### PR TITLE
Ability to override and pass additional props to the suggestions container

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ This component also has testing which makes use of the Places library in the Goo
 | [`renderTarget`](#renderTarget) | Function | ✓ | Renders the components/elements that you would like to have the list of suggestions popover. |
 | [`createAutocompleteRequest`](#createAutocompleteRequest) | Function | | Returns an object that modifies which suggestions are shown to the user. |
 | [`textFieldProps`](#textFieldProps) | Object | | Props that will be spread onto a `<TextField>` MUI component that is responsible for rendering the `<input>` element. If you would like to [control the state of the `<input>` element](#textFieldPropsValueProp) externally you must set the `value` key on the object passed to `textFieldProps`. |
+| [`suggestionsContainerProps`](#suggestionsContainerProps) | Object | | Props that will be included on the `<Popper>` container component which includes the list of suggestions. |
 
 <a name="onSuggestionSelected"></a>
 #### onSuggestionSelected (required)
@@ -182,6 +183,17 @@ const { inputValue } = getState()
 ```
 
 If you would like to have consistency between the controlled `<input>` elements state as well as any suggestions that are selected then you need to update the controlled state of the `<input>` element when a [suggestion is selected](#onSuggestionSelected). There is an example of how to do this in the [advanced usage section](#advancedUsage).
+
+<a name="suggestionsContainerProps"></a>
+#### suggestionsContainerProps
+
+A `<Popper>` component is used to contain the suggestions displayed to the user. It can be customised to meet your needs by supplying an object to the `suggestionsContainerProps` prop. All properties on the object supplied to the `suggestionsContainerProps` prop will be spread onto the `<Popper>` component. You can read more about the props that the `<Popper>` component accepts here: [`<Popper>` Github Repository](https://github.com/FezVrasta/react-popper)
+
+Below is an example of how to control the width of the suggestions container using the `style` property of the `suggestionsContainerProps` object:
+
+```javascript
+<MUIPlacesAutocomplete suggestionsContainerProps={{ style: { width: '400px' } }} />
+```
 
 <a name="geocodingFunctions"></a>
 ### Geocoding utility functions (latitude/longitude)

--- a/src/MUIPlacesAutocomplete.jsx
+++ b/src/MUIPlacesAutocomplete.jsx
@@ -29,7 +29,10 @@ export default class MUIPlacesAutocomplete extends React.Component {
   // * inputValue - current value of the controlled <input> element
   // * highlightedIndex - index of the currently highlighted menu item elements that have been
   // rendered
-  static renderSuggestionsContainer(suggestions, downshiftRenderProps) {
+  //
+  // The 'containerProps' argument expects an object of props that will be applied to the Popper
+  // and is generally used to override the style of how the container is rendered e.g. width
+  static renderSuggestionsContainer(suggestions, downshiftRenderProps, containerProps) {
     // Return null here if there are no suggestions to render. If we don't we will show a little box
     // that is empty and popped over the render target. This handles the case where a suggestion is
     // selected, the input value is updated, and then the user deletes the input value. This
@@ -63,11 +66,28 @@ export default class MUIPlacesAutocomplete extends React.Component {
     // will get the following warnings: NaN is an invalid value for the top/left css style property.
     // This is because the DOM provider/implementation we use when testing (jsdom) doesn't return
     // values for bounding client rect.
+    const {
+      style: _containerStyle,
+      modifiers: _containerModifiers,
+      placement: containerPlacement,
+      ...restContainerProps
+    } = containerProps
+    const containerStyle = _containerStyle || {}
+    const containerModifiers = _containerModifiers || {}
     return (
       <Popper
-        placement="top-start"
-        modifiers={({ inner: { enabled: true } })}
-        style={{ left: 0, right: 0, zIndex: 1 }}
+        placement={containerPlacement || 'top-start'}
+        modifiers={({
+          inner: containerModifiers.inner || { enabled: true },
+          ...containerModifiers,
+        })}
+        style={{
+          ...containerStyle,
+          left: containerStyle.left || 0,
+          right: containerStyle.right || 0,
+          zIndex: containerStyle.zIndex || 1,
+        }}
+        {...restContainerProps}
       >
         {({ popperProps, restProps }) => (
           <div
@@ -228,7 +248,7 @@ export default class MUIPlacesAutocomplete extends React.Component {
     highlightedIndex,
   }) {
     const { suggestions } = this.state
-    const { renderTarget, textFieldProps } = this.props
+    const { renderTarget, textFieldProps, suggestionsContainerProps } = this.props
 
     // We set the value of 'tag' on the <Manager> component to false to allow the rendering of
     // children instead of a specific DOM element.
@@ -249,6 +269,7 @@ export default class MUIPlacesAutocomplete extends React.Component {
           {isOpen ? MUIPlacesAutocomplete.renderSuggestionsContainer(
                       suggestions,
                       { getItemProps, inputValue, highlightedIndex },
+                      suggestionsContainerProps,
                       )
                   : null}
         </Manager>
@@ -281,9 +302,11 @@ MUIPlacesAutocomplete.propTypes = {
   renderTarget: PropTypes.func.isRequired,
   createAutocompleteRequest: PropTypes.func,
   textFieldProps: PropTypes.object,
+  suggestionsContainerProps: PropTypes.object,
 }
 
 MUIPlacesAutocomplete.defaultProps = {
   createAutocompleteRequest: inputValue => ({ input: inputValue }),
   textFieldProps: { autoFocus: false, placeholder: 'Search for a place', fullWidth: true },
+  suggestionsContainerProps: {},
 }

--- a/test/test.jsx
+++ b/test/test.jsx
@@ -306,6 +306,193 @@ describe('React component test: <MUIPlacesAutocomplete>', function () {
       expect(styleProps.zIndex).to.exist
       expect(styleProps.zIndex).to.be.equal(1)
     })
+
+    it('\'suggestionsContainerProps.style\' can be used to set \'width\' and retain defaults', function () {
+      const width = '400px'
+
+      mpaWrapper = mount(
+        <MUIPlacesAutocomplete
+          onSuggestionSelected={() => {}}
+          renderTarget={() => (<div />)}
+          suggestionsContainerProps={{
+            style: { width },
+          }}
+        />,
+      )
+
+      // To get suggestions to be rendered first simulate an input onChange event which will cause
+      // <Downshift> to believe that our autocomplete/dropdown is open...
+      mpaWrapper.find('input').simulate('change', { target: { value: searchInputValue } })
+
+      // Second set the start of our component to provide suggestions as if they were returned from
+      // the Google AutocompleteService...
+      mpaWrapper.setState({ suggestions: [{ description: 'Bellingham, WA, United States' }] })
+
+      const pWrapper = mpaWrapper.find('Popper')
+      expect(pWrapper.exists()).to.be.true
+
+      const styleProps = pWrapper.prop('style')
+      expect(styleProps).to.exist
+      expect(styleProps.width).to.exist
+      expect(styleProps.width).to.be.equal(width)
+      expect(styleProps.left).to.exist
+      expect(styleProps.left).to.be.equal(0)
+      expect(styleProps.right).to.exist
+      expect(styleProps.right).to.be.equal(0)
+      expect(styleProps.zIndex).to.exist
+      expect(styleProps.zIndex).to.be.equal(1)
+    })
+
+    it('\'suggestionsContainerProps.style\' can be used to override \'style\' defaults', function () {
+      const style = {
+        left: 50,
+        right: 15,
+        zIndex: 4,
+      }
+
+      mpaWrapper = mount(
+        <MUIPlacesAutocomplete
+          onSuggestionSelected={() => {}}
+          renderTarget={() => (<div />)}
+          suggestionsContainerProps={{ style }}
+        />,
+      )
+
+      // To get suggestions to be rendered first simulate an input onChange event which will cause
+      // <Downshift> to believe that our autocomplete/dropdown is open...
+      mpaWrapper.find('input').simulate('change', { target: { value: searchInputValue } })
+
+      // Second set the start of our component to provide suggestions as if they were returned from
+      // the Google AutocompleteService...
+      mpaWrapper.setState({ suggestions: [{ description: 'Bellingham, WA, United States' }] })
+
+      const pWrapper = mpaWrapper.find('Popper')
+      expect(pWrapper.exists()).to.be.true
+
+      const styleProps = pWrapper.prop('style')
+      expect(styleProps).to.exist
+      expect(styleProps.left).to.exist
+      expect(styleProps.left).to.be.equal(style.left)
+      expect(styleProps.right).to.exist
+      expect(styleProps.right).to.be.equal(style.right)
+      expect(styleProps.zIndex).to.exist
+      expect(styleProps.zIndex).to.be.equal(style.zIndex)
+    })
+
+    it('\'suggestionsContainerProps.modifiers\' can be used to set \'hide\' and retain defaults', function () {
+      const modifiers = { hide: { enabled: true } }
+
+      mpaWrapper = mount(
+        <MUIPlacesAutocomplete
+          onSuggestionSelected={() => {}}
+          renderTarget={() => (<div />)}
+          suggestionsContainerProps={{ modifiers }}
+        />,
+      )
+
+      // To get suggestions to be rendered first simulate an input onChange event which will cause
+      // <Downshift> to believe that our autocomplete/dropdown is open...
+      mpaWrapper.find('input').simulate('change', { target: { value: searchInputValue } })
+
+      // Second set the start of our component to provide suggestions as if they were returned from
+      // the Google AutocompleteService...
+      mpaWrapper.setState({ suggestions: [{ description: 'Bellingham, WA, United States' }] })
+
+      const pWrapper = mpaWrapper.find('Popper')
+      expect(pWrapper.exists()).to.be.true
+
+      const modifiersProps = pWrapper.prop('modifiers')
+      expect(modifiersProps).to.exist
+      expect(modifiersProps.inner).to.exist
+      expect(modifiersProps.inner.enabled).to.exist
+      expect(modifiersProps.inner.enabled).to.be.equal(true)
+      expect(modifiersProps.hide).to.exist
+      expect(modifiersProps.hide.enabled).to.exist
+      expect(modifiersProps.hide.enabled).to.be.equal(modifiers.hide.enabled)
+    })
+
+    it('\'suggestionsContainerProps.modifiers\' can be used to override \'inner\' default', function () {
+      const modifiers = { inner: { enabled: false } }
+
+      mpaWrapper = mount(
+        <MUIPlacesAutocomplete
+          onSuggestionSelected={() => {}}
+          renderTarget={() => (<div />)}
+          suggestionsContainerProps={{ modifiers }}
+        />,
+      )
+
+      // To get suggestions to be rendered first simulate an input onChange event which will cause
+      // <Downshift> to believe that our autocomplete/dropdown is open...
+      mpaWrapper.find('input').simulate('change', { target: { value: searchInputValue } })
+
+      // Second set the start of our component to provide suggestions as if they were returned from
+      // the Google AutocompleteService...
+      mpaWrapper.setState({ suggestions: [{ description: 'Bellingham, WA, United States' }] })
+
+      const pWrapper = mpaWrapper.find('Popper')
+      expect(pWrapper.exists()).to.be.true
+
+      const modifiersProps = pWrapper.prop('modifiers')
+      expect(modifiersProps).to.exist
+      expect(modifiersProps.inner).to.exist
+      expect(modifiersProps.inner.enabled).to.exist
+      expect(modifiersProps.inner.enabled).to.be.equal(modifiers.inner.enabled)
+    })
+
+    it('\'suggestionsContainerProps.placement\' can be used to override default', function () {
+      const placement = 'bottom'
+
+      mpaWrapper = mount(
+        <MUIPlacesAutocomplete
+          onSuggestionSelected={() => {}}
+          renderTarget={() => (<div />)}
+          suggestionsContainerProps={{ placement }}
+        />,
+      )
+
+      // To get suggestions to be rendered first simulate an input onChange event which will cause
+      // <Downshift> to believe that our autocomplete/dropdown is open...
+      mpaWrapper.find('input').simulate('change', { target: { value: searchInputValue } })
+
+      // Second set the start of our component to provide suggestions as if they were returned from
+      // the Google AutocompleteService...
+      mpaWrapper.setState({ suggestions: [{ description: 'Bellingham, WA, United States' }] })
+
+      const pWrapper = mpaWrapper.find('Popper')
+      expect(pWrapper.exists()).to.be.true
+
+      const placementProps = pWrapper.prop('placement')
+      expect(placementProps).to.exist
+      expect(placementProps).to.be.equal(placement)
+    })
+
+    it('\'suggestionsContainerProps\' can be used to add additional props', function () {
+      const eventsEnabled = true;
+
+      mpaWrapper = mount(
+        <MUIPlacesAutocomplete
+          onSuggestionSelected={() => {}}
+          renderTarget={() => (<div />)}
+          suggestionsContainerProps={{ eventsEnabled }}
+        />,
+      )
+
+      // To get suggestions to be rendered first simulate an input onChange event which will cause
+      // <Downshift> to believe that our autocomplete/dropdown is open...
+      mpaWrapper.find('input').simulate('change', { target: { value: searchInputValue } })
+
+      // Second set the start of our component to provide suggestions as if they were returned from
+      // the Google AutocompleteService...
+      mpaWrapper.setState({ suggestions: [{ description: 'Bellingham, WA, United States' }] })
+
+      const pWrapper = mpaWrapper.find('Popper')
+      expect(pWrapper.exists()).to.be.true
+
+      const placementProps = pWrapper.prop('eventsEnabled')
+      expect(placementProps).to.exist
+      expect(placementProps).to.be.equal(eventsEnabled)
+    })
   })
 
   describe('Consumes Google Maps JavaScript API correctly:', function () {


### PR DESCRIPTION
This change will allow users of this component to control the props on the Popper component. Therefore they can now control the width of the suggestions rendered to the screen as well as make a number of other custom modifications.

This should resolve issue https://github.com/Giners/mui-places-autocomplete/issues/40